### PR TITLE
fix the new test for ERA data set graphics

### DIFF
--- a/validator/tests/test_validation.py
+++ b/validator/tests/test_validation.py
@@ -545,12 +545,11 @@ class TestValidation(TestCase):
 
         boxplot_pngs = [ x for x in os.listdir(run_dir) if fnmatch.fnmatch(x, 'boxplot*.png')]
         self.__logger.debug(boxplot_pngs)
-        assert len(boxplot_pngs) == 8
+        assert len(boxplot_pngs) == 12
 
         overview_pngs = [ x for x in os.listdir(run_dir) if fnmatch.fnmatch(x, 'overview*.png')]
         self.__logger.debug(overview_pngs)
-        assert len(overview_pngs) == 8 * (v.dataset_configurations.count() - 1)
+        assert len(overview_pngs) == 12 * (v.dataset_configurations.count() - 1)
 
         # remove results 
         shutil.rmtree(run_dir)
-        self.delete_run(v)


### PR DESCRIPTION
since there are more graphs the assert statement is updated, and the double deletion of the test run is removed