### PR TITLE
Qa4sm 241 update time ranges (#109)

### DIFF
--- a/validator/forms/validation_run.py
+++ b/validator/forms/validation_run.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from validator.validation.globals import START_TIME, END_TIME
 
 from django.contrib.auth import get_user_model
 User = get_user_model()
@@ -50,8 +51,8 @@ class ValidationRunForm(forms.ModelForm):
         self.fields['min_lon'].initial = -11.20
         self.fields['max_lat'].initial = 71.60
         self.fields['max_lon'].initial = 48.30
-        self.fields['interval_from'].initial = datetime(1978, 1, 1).strftime('%Y-%m-%d')
-        self.fields['interval_to'].initial = datetime.now().strftime('%Y-%m-%d')
+        self.fields['interval_from'].initial = START_TIME
+        self.fields['interval_to'].initial = END_TIME
 
 
     def clean(self):

--- a/validator/templates/validator/validate.html
+++ b/validator/templates/validator/validate.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block content %}
-    <form action="{% url 'validation' %}" method="post" id="validation_form" data-options-url="{% url 'ajax_get_dataset_options' %}" version-options-url="{% url 'ajax_get_version_id' %}">
+    <form action="{% url 'validation' %}" method="post" id="validation_form" data-options-url="{% url 'ajax_get_dataset_options' %}" version-options-url="{% url 'ajax_get_version_id' %}" version-info-url="{% url 'ajax_get_version_info' %}">
         {% csrf_token %}
 
         {% with WIDGET_ERROR_CLASS='is-invalid' %}
@@ -670,7 +670,7 @@
             var datasetId = $(this).val();
             // var datasetName = $(this).text();
             var widgetId = $(this).attr('id');
-            var datasetName = $(`#${widgetId} option[value=${datasetId}]`).text()
+            var datasetName = $(`#${widgetId} option[value=${datasetId}]`).text();
             var filterWidgetId = widgetId.replace(/dataset$/, "filters");
             var paramFilterWidgetId = widgetId.replace(/dataset$/, "parametrised_filters");
             $.ajax({
@@ -687,21 +687,124 @@
                     $(filter_widget).html(return_data['filters']);
                     $(param_filter_widget).html(return_data['paramfilters']);
 
-                    console.log(datasetId, datasetName)
-
                     if(datasetName=='ISMN'){
-                        var default_value = $(version_widget).find('option')[0].value
-                        $('#id_target_hidden_input_version').val(default_value)
+                        var default_value = $(version_widget).find('option')[0].value;
+                        $('#id_target_hidden_input_version').val(default_value);
                     } else{
-                        $('#id_target_hidden_input_version').val('')
-                    }
-
+                        $('#id_target_hidden_input_version').val('');
+                    };
+                    start_ajax_to_set_valiadtion_period();
                 }
             });
 
         }
 
+        function ajax_take_versions_info(versionIds, funcs_set, args_names) {
+          /**
+           * Use ajax to read info of given dataset versions;
+           * @param  {object} versionIds list of version ids
+           * @param  {object} funcs_set  list of name of functions to be called
+           * @param  {object} args_names  list of name of arguments returned by ajax, which are passed to given functions
+           *
+           *
+           Example:
+           ajax_take_versions_info(versionsIds, [func1, func2, func3], [['intervals_from'], ['intervals_to'], ['intervals_from', 'intervals_to']])
+           will call func1 with argument 'intervals_from', func2 with 'intervals_to' and func3 with both of them.
+           Functions passed as a list must accept only one object-like argument.
+          */
+            var url = $("#validation_form").attr("version-info-url");
+            $.ajax({
+                url: url,
+                traditional: true,
+                data: {'version_id': versionIds},
+                success: function (return_data) {
+                  var intervals_from = return_data['intervals_from'];
+                  var intervals_to = return_data['intervals_to'];
+                  // calling functions given in the functions list
+                  ind = 0
+                  for (func in funcs_set){
+                    // taking values of arguments passed in the parameter args_names and creating a list of their values
+                    param_list = get_list_of_params(arguments[0], args_names[ind]);
+                    funcs_set[func](param_list);
+                    ind++;
+                  };
+                }
+            });
+          };
 
+          function get_list_of_params(args, args_names){
+            /**
+             * Returns a list of values assinged to arguments which names are give in args_names;
+             * @param  {object} args list of arguments returned by ajax function: arguments[0]
+             * @param  {object} args_names list of names of arguments returned by the ajax function which should be passed further
+            */
+            param_list = [];
+            for (arg_name in args_names){
+              var name = args_names[arg_name];
+              param_list.push(args[name]);
+            };
+            return param_list
+          };
+
+          function find_current_ids(){
+            // Finds all selects which have 'version' in name attribute
+            var versions_list = $('select[name*=version]');
+            var ids_list = [];
+            for(ind=0; ind<versions_list.length; ind++){
+              var version_id = parseInt(versions_list[ind].value);
+              if (!isNaN(version_id)){
+                ids_list.push(version_id)
+              };
+            };
+            return ids_list;
+          };
+//=========================== Time range related functions =====================================================
+          function convert_date_to_string(date){
+            // Converts date from Date() constructor to date format YYYY-MM-DD
+            var year = date.getFullYear();
+            var month = date.getMonth()+1;
+            if(month<=9){month = '0'+month};
+            var day = date.getDate();
+            if(day<=9){day = '0' + day};
+            return year + '-' + month + '-' + day;
+          };
+
+          function compare_and_set_time_ranges(params){
+            /**
+             * Compares given time ranges and sets the appropriate ones
+                into From and To fields in Validation Period section
+             * @param  {object} params list consisting of two lists: intervals_from and intervals_to
+            */
+
+            // take appropriate elements from params
+            var intervals_from = params[0];
+            var intervals_to = params[1];
+            dates_from = [];
+            dates_to = [];
+            // convert string into date
+            for (ind=0; ind<intervals_from.length; ind++){
+              dates_from.push(new Date(intervals_from[ind]));
+              dates_to.push(new Date(intervals_to[ind]));
+            };
+
+            // get maximum date from and minimum date to
+            var max_date_from = new Date(Math.max.apply(null, dates_from));
+            var min_date_to = new Date(Math.min.apply(null, dates_to));
+
+            //reconvert date to string
+            var max_date_from_str = convert_date_to_string(max_date_from);
+            var min_date_to_str = convert_date_to_string(min_date_to);
+
+            //set appropriate values
+            $('#id_interval_from').val(max_date_from_str);
+            $('#id_interval_to').val(min_date_to_str);
+          }
+
+          function start_ajax_to_set_valiadtion_period(){
+            var versionIds = find_current_ids();
+            ajax_take_versions_info(versionIds, [compare_and_set_time_ranges], [['intervals_from', 'intervals_to']]);
+          }
+//================================================================================
 
         function change_tab_name() {
             var datasetName = $(this).find('option:selected').text();
@@ -711,6 +814,7 @@
 
         {% for dc_form in dc_formset.forms %}
             $("#{{ dc_form.dataset.auto_id }}").change(ajax_change_dataset).change(change_tab_name).change(); // last change() to call change on pageload
+            $("#{{ dc_form.version.auto_id }}").change(start_ajax_to_set_valiadtion_period)
         {% endfor %}
 
         function get_version_id(){
@@ -727,7 +831,8 @@
 
 
         $("#{{ ref_dc_form.dataset.auto_id }}").change(ajax_change_dataset).change(); // last change() to call change on pageload
-        $('#id_ref-version').change(get_version_id)
+        $('#id_ref-version').change(get_version_id).change(start_ajax_to_set_valiadtion_period)
+
 
     </script>
 
@@ -971,6 +1076,7 @@
 
         $('#remove_dc_form').click(function() {
             removeTab('.dc_form', '.dc_form_link', 'datasets',  $('#add_dc_form'), $(this));
+            start_ajax_to_set_valiadtion_period();
         });
 
         function shiftTheButton(obj, buttonSelector){

--- a/validator/tests/test_views.py
+++ b/validator/tests/test_views.py
@@ -99,7 +99,7 @@ class TestViews(TransactionTestCase):
         self.public_views = ['login', 'logout', 'home', 'published_results', 'signup', 'signup_complete', 'terms',
                              'datasets', 'alpha', 'help', 'about', 'password_reset', 'password_reset_done',
                              'password_reset_complete', 'user_profile_deactivated']
-        self.parameter_views = ['result', 'ajax_get_dataset_options', 'ajax_get_version_id', 'password_reset_confirm', 'stop_validation']
+        self.parameter_views = ['result', 'ajax_get_dataset_options', 'ajax_get_version_id', 'password_reset_confirm', 'stop_validation', 'ajax_get_version_info']
         self.private_views = [p.name for p in urlpatterns if hasattr(p,
                                                                      'name') and p.name is not None and p.name not in self.public_views and p.name not in self.parameter_views]
 
@@ -853,3 +853,22 @@ class TestViews(TransactionTestCase):
         ## make sure we can't log in with the old password
         login_success = self.client.login(**{'username': self.credentials2['username'], 'password': orig_password})
         assert not login_success
+
+    def test_ajax_get_version_info_view(self):
+        url = reverse('ajax_get_version_info')
+        self.client.login(**self.credentials)
+        version_ids = [DatasetVersion.objects.get(short_name=globals.ISMN_V20191211).id,
+                       DatasetVersion.objects.get(short_name=globals.GLDAS_NOAH025_3H_2_1).id,
+                       DatasetVersion.objects.get(short_name=globals.C3S_V201912).id,
+                       DatasetVersion.objects.get(short_name=globals.SMOS_105_ASC).id]
+
+        response = self.client.get(url, {'version_id': version_ids})
+        self.assertEqual(response.status_code, 200)
+
+        return_data = json.loads(response.content)
+        self.assertEqual(len(return_data['intervals_from']), len(version_ids))
+        self.assertEqual(len(return_data['intervals_to']), len(version_ids))
+        assert return_data['intervals_from'], return_data['intervals_to']
+
+        response = self.client.get(url, {'version_id': ''})
+        self.assertEqual(response.status_code, 400)

--- a/validator/urls.py
+++ b/validator/urls.py
@@ -36,6 +36,8 @@ urlpatterns = [
 
     path('ajax/get-dataset-options/', views.ajax_get_dataset_options, name='ajax_get_dataset_options'),
     path('ajax/get-version-options/', views.ajax_get_version_id, name='ajax_get_version_id'),
+    path('ajax/get-version-info/', views.ajax_get_version_info, name='ajax_get_version_info'),
+
 
     path('user_profile/',views.user_profile, name='user_profile'),
     path('user_profile_deactivated/',views.user_profile_deactivated, name='user_profile_deactivated'),

--- a/validator/validation/globals.py
+++ b/validator/validation/globals.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from datetime import datetime
 
 
 OUTPUT_FOLDER = settings.MEDIA_ROOT
@@ -81,3 +82,7 @@ ESA_CCI_SM_A_sm = 'ESA_CCI_SM_A_sm'
 ESA_CCI_SM_C_sm = 'ESA_CCI_SM_C_sm'
 
 NOT_AS_REFERENCE = [SMAP, SMOS, ASCAT]
+
+START_TIME = datetime(1978, 1, 1).strftime('%Y-%m-%d')
+END_TIME = datetime.now().strftime('%Y-%m-%d')
+

--- a/validator/validation/validation.py
+++ b/validator/validation/validation.py
@@ -22,16 +22,41 @@ import pytz
 from valentina.celery import app
 from validator.mailer import send_val_done_notification
 from validator.models import CeleryTask
-from validator.models import ValidationRun
+from validator.models import ValidationRun, DatasetVersion
 from validator.validation.batches import create_jobs
 from validator.validation.filters import setup_filtering
 from validator.validation.globals import OUTPUT_FOLDER
 from validator.validation.graphics import generate_all_graphs
 from validator.validation.readers import create_reader
 from validator.validation.util import mkdir_if_not_exists, first_file_in
+from validator.validation.globals import START_TIME, END_TIME
 
 
 __logger = logging.getLogger(__name__)
+
+
+def _get_actual_time_range(val_run, dataset_version_id):
+    try:
+        vs_start = DatasetVersion.objects.get(pk=dataset_version_id).time_range_start
+        vs_start_time = datetime.strptime(vs_start, '%Y-%m-%d').date()
+
+        vs_end = DatasetVersion.objects.get(pk=dataset_version_id).time_range_end
+        vs_end_time = datetime.strptime(vs_end, '%Y-%m-%d').date()
+
+        val_start_time = val_run.interval_from.date()
+        val_end_time = val_run.interval_to.date()
+
+        actual_start = val_start_time.strftime('%Y-%m-%d') if val_start_time > vs_start_time \
+            else vs_start_time.strftime('%Y-%m-%d')
+        actual_end = val_end_time.strftime('%Y-%m-%d') if val_end_time < vs_end_time \
+            else vs_end_time.strftime('%Y-%m-%d')
+
+    except:
+        # exception will arise for ISMN, and for that one we can use entire range
+        actual_start = START_TIME
+        actual_end = END_TIME
+
+    return [actual_start, actual_end]
 
 
 def set_outfile(validation_run, run_dir):
@@ -86,6 +111,10 @@ def save_validation_config(validation_run):
             ds.setncattr('val_dc_variable_pretty_name' + str(i), dataset_config.variable.pretty_name)
 
             ds.setncattr('val_dc_filters' + str(i), filters)
+
+            actual_interval_from, actual_interval_to = _get_actual_time_range(validation_run, dataset_config.version.id)
+            ds.setncattr('val_dc_actual_interval_from' + str(i), actual_interval_from)
+            ds.setncattr('val_dc_actual_interval_to' + str(i), actual_interval_to)
 
             if ((validation_run.reference_configuration is not None) and
                 (dataset_config.id == validation_run.reference_configuration.id)):

--- a/validator/views/validation.py
+++ b/validator/views/validation.py
@@ -215,3 +215,30 @@ def ajax_get_version_id(request):
         }
 
     return JsonResponse(response_data)
+
+login_required(login_url='/login/')
+def ajax_get_version_info(request):
+    version_ids = request.GET.getlist('version_id')
+    try:
+        version_ids_int = [int(vid) for vid in version_ids]
+        versions = DatasetVersion.objects.filter(pk__in=version_ids_int)
+    except:
+        return HttpResponseBadRequest("Not a valid dataset version")
+    intervals_from = []
+    intervals_to = []
+    for version in versions:
+        if 'ISMN' in version.short_name:
+            time_from = val_globals.START_TIME
+            time_to = val_globals.END_TIME
+        else:
+            time_from = version.time_range_start
+            time_to = version.time_range_end
+        intervals_from.append(time_from)
+        intervals_to.append(time_to)
+
+    response_data = {
+        'intervals_from': intervals_from,
+        'intervals_to' : intervals_to
+        }
+    return JsonResponse(response_data)
+


### PR DESCRIPTION
* Revert "updating my fork"

* Updating my fork (#18)

* Update variables.json (#84)

Geophysical range for ESA CCI active changed to 0-100 instead of 0-1.

* Test master (#108)

* Add option to deactivate scaling (#98)

Co-authored-by: Wolfgang Preimesberger <wolfgang.preimesberger@geo.tuwien.ac.at>

* Bug fixing (#99)

* Update versions.json

* Update scheme.css

some styling added so that filter descriptions for smos don't cause a shift in the question mark sign

* Update filter_checkbox_option.html

Comment removed

* Ismn dialog window (#100)

* Qa4sm 389 ismn dialog window (#80)

* Revert "updating my fork"

* a bug fixed - default depth values were passed to the database instead of the ones chosen by user

* changed id of a checkbox for parametrized filters and the regular id passed into a hidden field, so that regardless it's disabled filter id is still passed to the database

* label moved before the hidden input, so that styling from css file works properly

* bug fixed: scaling data restored after removal datasets

* necessary filies added

* changed files added

* loading model ISMNNetworks enabled

* improved way of taking dataset name

* Update ismn_dialog.html

toggleISMNContinent function removed from depth selection

Co-authored-by: sheenaze <tercjak@awst>

* Update and rename 0021_ismnnetworks.py to 0023_ismnnetworks.py

Some cleansing in migration directory so that there were no conflicts

* 0022_auto_20201110_1524 added

migration file from 'no scaling task'

* Delete 0022_merge_20201001_0821.py

Don't need this merge anymore

Co-authored-by: sheenaze <tercjak@awst>

* All data sets on both sides (#101)

* Qa4sm 391 allowing all datasets (#81)

* Revert "updating my fork"

* a bug fixed - default depth values were passed to the database instead of the ones chosen by user

* changed id of a checkbox for parametrized filters and the regular id passed into a hidden field, so that regardless it's disabled filter id is still passed to the database

* label moved before the hidden input, so that styling from css file works properly

* bug fixed: scaling data restored after removal datasets

* necessary filies added

* changed files added

* loading model ISMNNetworks enabled

* improved way of taking dataset name

* restoring task 391

Co-authored-by: sheenaze <tercjak@awst>

* Update test_validation.py

* Update data_configuration.py

temporarily SMOS, SMAP and ASCAT are removed from the reference list

* Update datasets.html

give an information on dataset site

* Qa4sm 389 ismn dialog window (#80) (#86)

* Revert "updating my fork"

* a bug fixed - default depth values were passed to the database instead of the ones chosen by user

* changed id of a checkbox for parametrized filters and the regular id passed into a hidden field, so that regardless it's disabled filter id is still passed to the database

* label moved before the hidden input, so that styling from css file works properly

* bug fixed: scaling data restored after removal datasets

* necessary filies added

* changed files added

* loading model ISMNNetworks enabled

* improved way of taking dataset name

* Update ismn_dialog.html

toggleISMNContinent function removed from depth selection

Co-authored-by: sheenaze <tercjak@awst>

Co-authored-by: sheenaze <tercjak@awst>

* Fix bugs (#85) (#87)

* Revert "updating my fork"

* updated time range and geophysical range for cci active

* comment removed

* some styling added so that filter descriptions for smos dont cause a shift in the question mark sign

Co-authored-by: sheenaze <tercjak@awst>

Co-authored-by: sheenaze <tercjak@awst>

* Migrations added

0022_auto_20201110_1524.py and 0023_ismnnetworks.py added so to avoid conflicts with other branches

* Update and rename 0022_auto_20200923_1532.py to 0024_auto_20200923_1532.py

file name changed as well as the name of the file in the dependencies so to avoid conflicts while merging with other branches

* Delete 0023_merge_20201005_0813.py

File not needed anymore

* Delete 0021_ismnnetworks.py

File not needed, exchanged with file named 0023_ismnnetworks.py

* Delete 0022_merge_20201001_0821.py

File not needed anymore

* Update globals.py

Added datasets which are temporarily excluded as the reference ones

* Update datasets.py

Excluded datasests added to the dataset view so that appropriate information will be displayed

* Update data_configuration.py

Names of datasets that should be excluded taken from globals

* Update datasets.html

excluded datasets names passed in the context

Co-authored-by: sheenaze <tercjak@awst>

* Service statistics (#104)

* Qa4sm 173 statistics (#103)

* Revert "updating my fork"

* new model statistics created and added to __init__.py

* new model registered so that it is visible in the admin panel

* Statistics panel created and somehow developed

* js plotly library added so that it is possible to create plots

* html template for statistics panel added and developed

* plot class added to css file; number of validations in time added to the statistics

* some edorial work done

* method for retrieving dataset info for plot and a plot of these info added

* added some formating to statistics site

* some info on a user retrieved and showed on the statistics site

* function for getting info on datasets improved, so that it can also take into account a user

* some code cleansing and formating added

* datasets plot for each user added; Remark: still required improvement for users who hasnt run any validations!

* dataset plots now also done for users with no validations

* x-axis range for validations in time plot extendend to the end of the last day

* some code cleansing done

* some code cleansing done

* small code cleansing

* migration added

Co-authored-by: sheenaze <tercjak@awst>

* Rename 0022_statistics.py to 0025_statistics.py

Name of migration changed so that after merging with test_master there was no conflict

* Update 0025_statistics.py

The dependency changed

* Update 0025_statistics.py

.py removed from the name of the dependency

Co-authored-by: sheenaze <tercjak@awst>

* Update scheme.css

label width set to 95% of div's width only for dc_form_container

* Update scheme.css

removed duplicated code

* Update qa4sm_env.yml

Updated environment

* Update qa4sm_statistics.py

unnecessary print deleted

* Update release_procedure.md

Release procedure updated - environment recreation extended.

* Update qa4sm_env.yml

environment updated together with the newest pytest version

* Update create_conda_env.sh

minimum version of qa4sm-reader added

* Get back to previous pytest version

as the newest one still causes errors

* Update create_conda_env.sh

The lowest properly working version of qa4sm-reader is 0.3.3 not 0.3.2

Co-authored-by: Wolfgang Preimesberger <wolfgang.preimesberger@geo.tuwien.ac.at>
Co-authored-by: sheenaze <tercjak@awst>

Co-authored-by: Wolfgang Preimesberger <wolfgang.preimesberger@geo.tuwien.ac.at>
Co-authored-by: sheenaze <tercjak@awst>

* preparing url and new view for a new ajax function

* validate.html - added ajax function for taking time ranges

* start and end time moved to globals

* corrected url and appropriate ajax function added to validation.py view

* ajax function developed

* appendind intervals imprved

* ajax function name changed, so that it indicates that it refers to more than one versions

* ajax function for taking dataset version info developed in the way that now it is possible to pass any function to it

* some code cleansing done, function for comparing and setting time ranges added, together with a function for transforming Date() into string

* function for setting time ranges attached to version selector and to dataset romover

* some comments added and some code cleansing applied

* ajax_get_version_info added to parameters_views in test_views

* list comprehension embraced by try so that in case of no version id error 400 was triggered

* basic test added for ajax_get_version_info view

* test fro ajax_get_version_info view improved

Co-authored-by: Wolfgang Preimesberger <wolfgang.preimesberger@geo.tuwien.ac.at>
Co-authored-by: sheenaze <tercjak@awst>