### PR TITLE
Qa4sm 408 smos smap ascat (#148)

### DIFF
--- a/environment/create_conda_env.sh
+++ b/environment/create_conda_env.sh
@@ -100,7 +100,7 @@ pip install --upgrade --force-reinstall netcdf4
 pip install pytesmo
 pip install ismn
 pip install requests
-pip install qa4sm-reader>=0.3.3
+pip install qa4sm-reader>=0.3.4
 
 cd $TEMP_DIR
 

--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -166,7 +166,7 @@ dependencies:
     - pytest-cov==2.10.1
     - pytest-django==4.1.0
     - pytest-mpl==0.12
-    - qa4sm-reader==0.3.3
+    - git+https://github.com/sheenaze/qa4sm-reader.git@update_irregular_plots
     - redis==3.5.3
     - repurpose==0.8
     - seaborn==0.11.0

--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -166,7 +166,7 @@ dependencies:
     - pytest-cov==2.10.1
     - pytest-django==4.1.0
     - pytest-mpl==0.12
-    - git+https://github.com/sheenaze/qa4sm-reader.git@update_irregular_plots
+    - git+https://github.com/TUW-GEO/qa4sm-reader.git
     - redis==3.5.3
     - repurpose==0.8
     - seaborn==0.11.0

--- a/validator/templates/validator/datasets.html
+++ b/validator/templates/validator/datasets.html
@@ -74,7 +74,7 @@
             </tbody>
         </table>
         {% if not ref_flag %}
-            <sup>*</sup> dataset temporarily excluded from the reference list for technical reasons<br>
+        {% if not_as_reference %}    <sup>*</sup> dataset temporarily excluded from the reference list for technical reasons<br> {% endif %}
         {% endif %}
         <br>
 

--- a/validator/tests/test_validation.py
+++ b/validator/tests/test_validation.py
@@ -554,49 +554,47 @@ class TestValidation(TestCase):
         self.check_results(new_run)
         self.delete_run(new_run)
 
-#     @pytest.mark.long_running
-#     def test_validation_smap_ref(self):
-#         run = self.generate_default_validation()
-#         run.user = self.testuser
+    # @pytest.mark.long_running
+    def test_validation_smap_ref(self):
+        run = self.generate_default_validation()
+        run.user = self.testuser
 
-#         run.reference_configuration.dataset = Dataset.objects.get(short_name=globals.SMAP)
-#         run.reference_configuration.version = DatasetVersion.objects.get(short_name=globals.SMAP_V5_PM)
-#         run.reference_configuration.variable = DataVariable.objects.get(short_name=globals.SMAP_soil_moisture)
-#         run.reference_configuration.filters.add(DataFilter.objects.get(name='FIL_ALL_VALID_RANGE'))
+        run.reference_configuration.dataset = Dataset.objects.get(short_name=globals.SMAP)
+        run.reference_configuration.version = DatasetVersion.objects.get(short_name=globals.SMAP_V5_PM)
+        run.reference_configuration.variable = DataVariable.objects.get(short_name=globals.SMAP_soil_moisture)
+        run.reference_configuration.filters.add(DataFilter.objects.get(name='FIL_ALL_VALID_RANGE'))
 
-#         run.reference_configuration.save()
+        run.reference_configuration.save()
 
-#         run.interval_from = datetime(2017, 1, 1, tzinfo=UTC)
-#         run.interval_to = datetime(2018, 1, 1, tzinfo=UTC)
-#         # different window is used here, because for the default one there is too much memory needed to create and save
-#         # plots
-#         run.min_lat = 20.32
-#         run.min_lon = -157.47
-#         run.max_lat = 21.33
-#         run.max_lon = -155.86
+        run.interval_from = datetime(2017, 1, 1, tzinfo=UTC)
+        run.interval_to = datetime(2018, 1, 1, tzinfo=UTC)
 
-#         run.save()
+        run.min_lat = self.hawaii_coordinates[0]
+        run.min_lon = self.hawaii_coordinates[1]
+        run.max_lat = self.hawaii_coordinates[2]
+        run.max_lon = self.hawaii_coordinates[3]
 
-#         for config in run.dataset_configurations.all():
-#             if config != run.reference_configuration:
-#                 #                 config.filters.add(DataFilter.objects.get(name='FIL_C3S_FLAG_0'))
-#                 config.filters.add(DataFilter.objects.get(name='FIL_ALL_VALID_RANGE'))
-#             config.save()
+        run.save()
 
-#         run_id = run.id
+        for config in run.dataset_configurations.all():
+            if config != run.reference_configuration:
+                config.filters.add(DataFilter.objects.get(name='FIL_ALL_VALID_RANGE'))
+            config.save()
 
-#         ## run the validation
-#         val.run_validation(run_id)
+        run_id = run.id
 
-#         new_run = ValidationRun.objects.get(pk=run_id)
-#         print(new_run)
-#         assert new_run
+        ## run the validation
+        val.run_validation(run_id)
 
-#         assert new_run.total_points == 15, "Number of gpis is off"
-#         assert new_run.error_points == 0, "Too many error gpis"
-#         assert new_run.ok_points == 15, "OK points are off"
-#         self.check_results(new_run)
-#         self.delete_run(new_run)
+        new_run = ValidationRun.objects.get(pk=run_id)
+        print(new_run)
+        assert new_run
+
+        assert new_run.total_points == 140, "Number of gpis is off"
+        assert new_run.error_points == 0, "Too many error gpis"
+        assert new_run.ok_points == 140, "OK points are off"
+        self.check_results(new_run)
+        self.delete_run(new_run)
 
     @pytest.mark.long_running
     def test_validation_ascat_ref(self):

--- a/validator/validation/globals.py
+++ b/validator/validation/globals.py
@@ -81,7 +81,10 @@ ESA_CCI_SM_P_sm = 'ESA_CCI_SM_P_sm'
 ESA_CCI_SM_A_sm = 'ESA_CCI_SM_A_sm'
 ESA_CCI_SM_C_sm = 'ESA_CCI_SM_C_sm'
 
-NOT_AS_REFERENCE = [SMAP, SMOS, ASCAT]
+
+# left empty, because if in the future we want to exclude some datasets from the reference group it will be enough to
+# insert it's shortname to the list
+NOT_AS_REFERENCE = []
 
 IRREGULAR_GRIDS = {'SMAP' : 0.35,
                    'SMOS' : 0.25,


### PR DESCRIPTION
* using ascat, smos and smap as reference require qa4sm-reader 0.3.4 or higher

* ascat, smap and smos removed from NOT_AS_REFERENCE list, but the list left just in case

* comment refering to datasets excluded from being used as reference ones improved, so that it shows only when there are such datasets

* link to the appropriate repository instead of verion number insterted for qa4sm-reader package

* test for smap validation used as a reference one added

* env .yml file improved