### PR TITLE
Load settings (#159)

### DIFF
--- a/validator/forms/custom_widgets.py
+++ b/validator/forms/custom_widgets.py
@@ -26,6 +26,11 @@ class FilterCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
                     duper['parameterised'] = fil.parameterised
                     duper['dialog_name'] = fil.dialog_name
                     duper['default_parameter'] = fil.default_parameter
+                    if ("initial_params" in attrs
+                            and attrs["initial_params"] is not None):
+                        duper["initial_params"] = attrs["initial_params"][index]
+                    else:
+                        duper["initial_params"] = fil.default_parameter
                     break
 
         return duper

--- a/validator/forms/data_configuration.py
+++ b/validator/forms/data_configuration.py
@@ -53,6 +53,40 @@ class DatasetConfigurationForm(forms.ModelForm):
         else:
             self.fields["dataset"].queryset = Dataset.objects.filter(is_only_reference=is_reference)
 
+        # This translates the initial filter list to a string of filter ids
+        # separated by an underscore. This string is passed to the ajax call
+        # `ajax_change_dataset` in validate.html, and then further passed to
+        # `ajax_get_dataset_options` in validation.py.
+        if "filters" in self.initial:
+            self.initial_filters = ",".join(map(
+                lambda x: str(getattr(x, "id")), list(self.initial["filters"])
+            ))
+        else:
+            self.initial_filters = ""
+        if "parametrised_filters" in self.initial:
+            self.initial_paramfilters = ",".join(map(
+                lambda x: str(getattr(x, "id")),
+                list(self.initial["parametrised_filters"])
+            ))
+            if "paramfilter_params" in self.initial:
+                self.initial_paramfilter_params = ";".join(
+                    self.initial["paramfilter_params"]
+                )
+            else:
+                self.initial_paramfilter_params = ""
+        else:
+            self.initial_paramfilters = ""
+            self.initial_paramfilter_params = ""
+        # do the same for version and variable
+        if "version" in self.initial:
+            self.initial_version = str(self.initial["version"].id)
+        else:
+            self.initial_version = ""
+        if "variable" in self.initial:
+            self.initial_variable = str(self.initial["version"].id)
+        else:
+            self.initial_variable = ""
+
     def _save_m2m(self):
         # treat the parametrised filters separately, remove them now, save after calling super
         param_filters = None

--- a/validator/forms/validation_run.py
+++ b/validator/forms/validation_run.py
@@ -46,7 +46,7 @@ class ValidationRunForm(forms.ModelForm):
         self.fields['max_lat'].required = False
         self.fields['max_lon'].required = False
 
-        ## give default/initial values to widgets
+        # default/initial values
         self.fields['min_lat'].initial = 34.00
         self.fields['min_lon'].initial = -11.20
         self.fields['max_lat'].initial = 71.60
@@ -54,6 +54,22 @@ class ValidationRunForm(forms.ModelForm):
         self.fields['interval_from'].initial = START_TIME
         self.fields['interval_to'].initial = END_TIME
 
+        # in case the form got passed initial values, use them instead
+        for name in self.fields:
+            self.fields[name].initial = self.get_initial_for_field(
+                self.fields[name], name
+            )
+
+        # if the initial interval_from or interval_to value is not
+        # START_TIME/END_TIME, we need to disable the ajax call in
+        # validate.html
+        self.disable_ajax_validation_period = (
+            self.fields["interval_from"].initial != START_TIME
+            or self.fields["interval_to"].initial != END_TIME
+        )
+
+        # remember initial tcol value to set it correctly in setTcLock
+        self.initial_tcol = self.fields["tcol"].initial
 
     def clean(self):
         values = super(ValidationRunForm, self).clean()

--- a/validator/static/css/scheme.css
+++ b/validator/static/css/scheme.css
@@ -81,6 +81,10 @@
   width: 95%;
 }
 
+#id_ref-filters div > label.custom-control-label{
+  width: 95%;
+}
+
 .alert-danger {
     color: rgb(255, 108, 92);
     background-color: rgba(255, 108, 92, .15);

--- a/validator/templates/validator/published_results.html
+++ b/validator/templates/validator/published_results.html
@@ -71,6 +71,7 @@
 
                             <div class="col-sm" style="text-align: right; max-width: 6.8rem;">
                                 <a class="btn btn-sm btn-primary btn-action" href="{% url 'result' valrun.id %}" title="View results"><span class="fas fa-folder-open"></span></a>
+                                <a class="btn btn-sm btn-primary btn-action" href="{% url 'validation' %}?valrun_uuid={{ valrun.id }}" title="Load validation settings"><span class="fas fa-redo"></span></a>
                                 {% if current_user %}
                                     {% if valrun not in copied_runs %}
                                         <button class="btn btn-sm btn-primary btn-action" title="Track this validation" onclick="ajax_attach_validation('{{ valrun.id}}')"><span class="fas fa-plus"></span></button>

--- a/validator/templates/validator/result.html
+++ b/validator/templates/validator/result.html
@@ -158,7 +158,7 @@
                     </ul>
 
                     {% if is_owner and val.is_unpublished %}
-                        <div style="float: right;" class="patchButtonGroup{% if val.publishing_in_progress %} collapse {% endif %}">
+                        <div style="float: right" class="patchButtonGroup{% if val.publishing_in_progress %} collapse {% endif %}">
                             <button class="btn btn-sm btn-primary" title="Remove result" onclick="ajax_delete_result('{{ val.id }}', true)"><span class="fas fa-times"></span> Remove</button>
                             {% if val.is_archived %}
                                 <button class="btn btn-sm btn-primary" title="Un-archive" onclick="ajax_archive_result('{{ val.id }}', false)"><span class="fas fa-calendar-alt"></span> Un-archive</button>
@@ -171,6 +171,7 @@
                                     <span class="fas fa-book" ></span> Publish
                                 </button>
                             {% endif %}
+                            <a class="btn btn-sm btn-primary" title="Load settings" href="{% url 'validation' %}?valrun_uuid={{ val.id }}"><span class="fas fa-redo"></span> Load settings</a>
                         </div>
                         {% if val.output_file %}
                             <div class="publishingNote small text-muted {% if not val.publishing_in_progress %} collapse {% endif %}" style="float: right">
@@ -180,6 +181,7 @@
                         {% endif %}
                     {% else %}
                     <div style="float: right;" class="patchButtonGroup">
+                        <a class="btn btn-sm btn-primary" title="Load settings" href="{% url 'validation' %}?valrun_uuid={{ val.id }}"><span class="fas fa-redo"></span> Load settings</a>
                         {% if current_user %}
                             {% if is_copied %}
                                 <button class="btn btn-sm btn-primary" title="Remove this validation from your list" onclick="ajax_detach_validation('{{ val.id }}', false)"><span class="fas fa-times"></span> Untrack </button>

--- a/validator/templates/validator/user_runs.html
+++ b/validator/templates/validator/user_runs.html
@@ -139,27 +139,29 @@
                                 {% endif %}
                             </div>
 
-                            <div class="col-sm" style="text-align: right; max-width: 8.75rem">
-                                <a class="btn btn-sm btn-primary btn-action" href="{% url 'result' valrun.id %}" title="View results"><span class="fas fa-folder-open"></span></a>
+                            <div class="col-sm" style="text-align: right; max-width: 12rem">
                                 {% if valrun.progress > -1 and valrun.progress < 100 and valrun.end_time == null %}
-                                <button class="btn btn-sm btn-primary btn-action" title="Cancel validation" onclick="ajax_stop_validation('{{ valrun.id }}')"><span class="fas fa-stop"></span></button>
+                                    <button class="btn btn-sm btn-primary btn-action" title="Cancel validation" onclick="ajax_stop_validation('{{ valrun.id }}')"><span class="fas fa-stop"></span></button>
                                 {% endif %}
+                                <a class="btn btn-sm btn-primary btn-action" href="{% url 'result' valrun.id %}" title="View results"><span class="fas fa-folder-open"></span></a>
                                 {% if valrun.end_time %}
                                     {% if valrun.output_file %}
                                     <a class="btn btn-sm btn-primary btn-action" href="{{ valrun.output_dir_url }}graphs.zip" title="Download all graphs"><span class="fas fa-download"></span></a>
                                     <a class="btn btn-sm btn-primary btn-action" href="{{ valrun.output_file.url }}" title="Download NetCDF"><span class="fas fa-file-download"></span></a>
                                 {% endif %}
-                                    {% if valrun.is_unpublished %}
-                                        <span class="patchButtonGroup{% if valrun.publishing_in_progress %} collapse {% endif %}">
-                                            <button class="btn btn-sm btn-primary btn-action" title="Remove result" onclick="ajax_delete_result('{{ valrun.id }}', false)"><span class="fas fa-times"></span></button>
-                                            {% if valrun.is_archived %}
-                                                <button class="btn btn-sm btn-primary btn-action" title="Un-archive" onclick="ajax_archive_result('{{ valrun.id }}', false)"><span class="fas fa-calendar-alt"></span></button>
-                                            {% else %}
-                                                <button class="btn btn-sm btn-primary btn-action" title="Extend lifespan" onclick="ajax_extend_result('{{ valrun.id }}', true)"><span class="fas fa-calendar-plus"></span></button>
-                                                <button class="btn btn-sm btn-primary btn-action" title="Archive" onclick="ajax_archive_result('{{ valrun.id }}', true)"><span class="fas fa-archive"></span></button>
-                                            {% endif %}
-                                        </span>
-                                    {% endif %}
+                                <br>
+                                {% if valrun.is_unpublished %}
+                                    <span class="patchButtonGroup{% if valrun.publishing_in_progress %} collapse {% endif %}">
+                                        <button class="btn btn-sm btn-primary btn-action" title="Remove result" onclick="ajax_delete_result('{{ valrun.id }}', false)"><span class="fas fa-times"></span></button>
+                                        {% if valrun.is_archived %}
+                                            <button class="btn btn-sm btn-primary btn-action" title="Un-archive" onclick="ajax_archive_result('{{ valrun.id }}', false)"><span class="fas fa-calendar-alt"></span></button>
+                                        {% else %}
+                                            <button class="btn btn-sm btn-primary btn-action" title="Extend lifespan" onclick="ajax_extend_result('{{ valrun.id }}', true)"><span class="fas fa-calendar-plus"></span></button>
+                                            <button class="btn btn-sm btn-primary btn-action" title="Archive" onclick="ajax_archive_result('{{ valrun.id }}', true)"><span class="fas fa-archive"></span></button>
+                                        {% endif %}
+                                    </span>
+                                {% endif %}
+                                <a class="btn btn-sm btn-primary btn-action" href="{% url 'validation' %}?valrun_uuid={{ valrun.id }}" title="Load validation settings"><span class="fas fa-redo"></span></a>
                                 {% endif %}
                             </div>
                         </div>

--- a/validator/templates/validator/validate.html
+++ b/validator/templates/validator/validate.html
@@ -685,7 +685,7 @@
     </script>
 
     <script type="text/javascript">
-        function ajax_change_dataset() {
+        function ajax_change_dataset(event) {
             var url = $("#validation_form").attr("data-options-url");
             var datasetId = $(this).val();
             // var datasetName = $(this).text();
@@ -693,9 +693,22 @@
             var datasetName = $(`#${widgetId} option[value=${datasetId}]`).text();
             var filterWidgetId = widgetId.replace(/dataset$/, "filters");
             var paramFilterWidgetId = widgetId.replace(/dataset$/, "parametrised_filters");
+	    var initialFilters = event.data.initialFilters;
+	    var initialParamfilters = event.data.initialParamfilters;
+	    var initialParamfilterParams = event.data.initialParamfilterParams;
+            var initialVersion = event.data.initialVersion;
+            var initialVariable = event.data.initialVariable;
+            var disableAjaxValidationPeriod = event.data.disableAjaxValidationPeriod;
             $.ajax({
                 url: url,
-                data: { 'dataset_id': datasetId, 'filter_widget_id': filterWidgetId, 'param_filter_widget_id': paramFilterWidgetId },
+                data: { 'dataset_id': datasetId,
+			'filter_widget_id': filterWidgetId,
+			'param_filter_widget_id': paramFilterWidgetId,
+		        'initial_filters': initialFilters,
+                        'initial_paramfilters': initialParamfilters,
+                        'initial_paramfilter_params': initialParamfilterParams,
+		        'initial_version': initialVersion,
+		        'initial_variable': initialVariable },
                 success: function (return_data) {
                     var dataset_widget = "#" + widgetId;
                     var version_widget = dataset_widget.replace(/dataset$/, "version");
@@ -713,7 +726,9 @@
                     } else{
                         $('#id_target_hidden_input_version').val('');
                     };
-                    start_ajax_to_set_valiadtion_period();
+                    if(disableAjaxValidationPeriod == "False") {
+                        start_ajax_to_set_validation_period();
+                    }
                 }
             });
         }
@@ -819,9 +834,9 @@
             $('#id_interval_to').val(min_date_to_str);
           }
 
-          function start_ajax_to_set_valiadtion_period(){
-            var versionIds = find_current_ids();
-            ajax_take_versions_info(versionIds, [compare_and_set_time_ranges], [['intervals_from', 'intervals_to']]);
+          function start_ajax_to_set_validation_period(){
+              var versionIds = find_current_ids();
+              ajax_take_versions_info(versionIds, [compare_and_set_time_ranges], [['intervals_from', 'intervals_to']]);
           }
 //================================================================================
       
@@ -832,8 +847,16 @@
         }
 
         {% for dc_form in dc_formset.forms %}
-            $("#{{ dc_form.dataset.auto_id }}").change(ajax_change_dataset).change(change_tab_name).change(); // last change() to call change on pageload
-            $("#{{ dc_form.version.auto_id }}").change(start_ajax_to_set_valiadtion_period)
+            $("#{{ dc_form.dataset.auto_id }}").change(
+                {initialFilters: "{{ dc_form.initial_filters }}",
+                 initialParamfilters: "{{ dc_form.initial_paramfilters }}",
+                 initialParamfilterParams: "{{ dc_form.initial_paramfilter_params }}",
+                 initialVersion: "{{ dc_form.initial_version }}",
+                 initialVariable: "{{ dc_form.initial_variable}}",
+                 disableAjaxValidationPeriod: "{{ val_form.disable_ajax_validation_period }}"},
+                ajax_change_dataset
+            ).change(change_tab_name).change(); // last change() to call change on pageload
+            $("#{{ dc_form.version.auto_id }}").change(start_ajax_to_set_validation_period)
         {% endfor %}
 
         function get_version_id(){
@@ -848,10 +871,16 @@
             }
         }
 
-
-        $("#{{ ref_dc_form.dataset.auto_id }}").change(ajax_change_dataset).change(); // last change() to call change on pageload
-        $('#id_ref-version').change(get_version_id).change(start_ajax_to_set_valiadtion_period)
-
+        $("#{{ ref_dc_form.dataset.auto_id }}").change(
+            {initialFilters: "{{ ref_dc_form.initial_filters }}",
+             initialParamfilters: "{{ ref_dc_form.initial_paramfilters }}",
+             initialParamfilterParams: "{{ ref_dc_form.initial_paramfilter_params }}",
+             initialVersion: "{{ ref_dc_form.initial_version }}",
+             initialVariable: "{{ ref_dc_form.initial_variable }}",
+             disableAjaxValidationPeriod: "{{ val_form.disable_ajax_validation_period }}"},
+            ajax_change_dataset
+        ).change(); // last change() to call change on pageload
+        $('#id_ref-version').change(get_version_id).change(start_ajax_to_set_validation_period)
 
     </script>
 
@@ -970,12 +999,13 @@
             setTcLock();
         });
 
-        function setTcLock() {
+        function setTcLock(checked = false) {
             var formsetPrefix = 'datasets';
             var totalSelector = '#id_' + formsetPrefix + '-TOTAL_FORMS';
             var totalNoForms = $(totalSelector).val();
             var n_datasets = parseInt(totalNoForms) + 1
             if ( n_datasets >= 3) {
+                $('#tcol').prop('checked', checked);
                 $('#tcol').prop('disabled', false);
             } else {
                 $('#tcol').prop('checked', false);
@@ -1095,7 +1125,7 @@
 
         $('#remove_dc_form').click(function() {
             removeTab('.dc_form', '.dc_form_link', 'datasets',  $('#add_dc_form'), $(this));
-            start_ajax_to_set_valiadtion_period();
+            start_ajax_to_set_validation_period();
         });
 
         function set_after(first_element_selector, second_element_selector){
@@ -1189,6 +1219,10 @@
       if($('#id_datasets-TOTAL_FORMS') >= $('#id_datasets-MIN_NUM_FORMS')){
         set_after('.dc_form_link.nav-item.nav-link.active', '#remove_dc_form')
       }
+      // and here the same just for tcol, but make sure to remember the
+      // original state
+      setTcLock("{{ val_form.initial_tcol|yesno:"true,false" }}");
+
 
       if ('{{if_run_exists}}' == 'True' && '{{is_published}}' == 'True'){
         var url_to_go = $('#pub_validate-confirm').attr('data-url')

--- a/validator/templates/widgets/filter_checkbox_option.html
+++ b/validator/templates/widgets/filter_checkbox_option.html
@@ -16,6 +16,6 @@
     {% endif %}
     <span class="input-group-text fas fa-question-circle help-icon" title="{{ widget.help_text }}"></span>
     {% if widget.parameterised  %}
-        <input type="hidden" id="{{ widget.attrs.id }}_params" value="{{ widget.default_parameter }}" data-default_val="{{ widget.default_parameter }}" name="{{ widget.name }}_params">
+        <input type="hidden" id="{{ widget.attrs.id }}_params" value="{{ widget.initial_params }}" data-default_val="{{ widget.default_parameter }}" name="{{ widget.name }}_params">
     {% endif %}
 </div>

--- a/validator/tests/test_views.py
+++ b/validator/tests/test_views.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 import io
 import json
 import logging
+from lxml.html import document_fromstring
 from re import findall as regex_find
 from time import sleep
 import time
@@ -24,7 +25,7 @@ from pytz import UTC
 from pytz import utc
 
 from validator.forms.user_profile import UserProfileForm
-from validator.models import ValidationRun
+from validator.models import ValidationRun, DatasetConfiguration
 from validator.models.dataset import Dataset
 from validator.models.filter import DataFilter
 from validator.models.settings import Settings
@@ -93,8 +94,52 @@ class TestViews(TransactionTestCase):
         ## Create a test validation run with a specific id so that it can
         ## be accessed via a URL containing that id
         self.testrun = ValidationRun.objects.create(**run_params)
+        # set some values to some of the settings
+        self.testrun.min_lat = -30
+        self.testrun.max_lat = 30
         ## make sure the run's output file name is set:
         self.testrun.output_file.name = str(self.testrun.id) + '/foobar.nc'
+        self.testrun.save()
+
+        # create data and reference configuration, required to rerun a
+        # validation
+        # uses two datasets and some non-default filters
+        data_c = DatasetConfiguration()
+        data_c.validation = self.testrun
+        data_c.dataset = Dataset.objects.get(short_name='C3S')
+        data_c.version = DatasetVersion.objects.get(short_name='C3S_V201812')
+        data_c.variable = DataVariable.objects.get(short_name='C3S_sm')
+        data_c.save()
+        filters = list(DataFilter.objects.filter(name="FIL_ALL_VALID_RANGE"))
+        data_c.filters.set([fil.id for fil in filters])
+        data_c.save()
+        other_data_c = DatasetConfiguration()
+        other_data_c.validation = self.testrun
+        other_data_c.dataset = Dataset.objects.get(short_name='SMOS')
+        other_data_c.version = DatasetVersion.objects.get(
+            short_name='SMOS_105_ASC'
+        )
+        other_data_c.variable = DataVariable.objects.get(short_name='SMOS_sm')
+        other_data_c.save()
+        filters = (
+            list(DataFilter.objects.filter(name="FIL_ALL_VALID_RANGE"))
+            + list(DataFilter.objects.filter(name="FIL_SMOS_UNFROZEN"))
+        )
+        other_data_c.filters.set([fil.id for fil in filters])
+        other_data_c.save()
+        ref_c = DatasetConfiguration()
+        ref_c.validation = self.testrun
+        ref_c.dataset = Dataset.objects.get(short_name='ISMN')
+        ref_c.version = DatasetVersion.objects.get(
+            short_name='ISMN_V20180712_MINI'
+        )
+        ref_c.variable = DataVariable.objects.get(
+            short_name='ISMN_soil_moisture'
+        )
+        ref_c.save()
+
+        self.testrun.reference_configuration = ref_c
+        self.testrun.scaling_ref = ref_c
         self.testrun.save()
 
         self.public_views = ['login', 'logout', 'home', 'published_results', 'signup', 'signup_complete', 'terms',
@@ -430,16 +475,43 @@ class TestViews(TransactionTestCase):
         assert form.cleaned_data["sort_order"] == "desc"
 
     def test_ajax_get_dataset_options_view(self):
+        ismn_networks = (
+            "BNZ-LTER,COSMOS,FLUXNET-AMERIFLUX,iRON,PBO-H2O,RISMA,SCAN,USCRN"
+            )
+        ismn_depths = "0,0.5"
         url = reverse('ajax_get_dataset_options')
         self.client.login(**self.credentials)
-        response = self.client.get(url, {'dataset_id': Dataset.objects.get(short_name=globals.GLDAS).id,
-                                         'filter_widget_id': 'id_datasets-0-filters',
-                                         'param_filter_widget_id': 'id_datasets-0-paramfilters'})
+        response = self.client.get(
+            url,
+            {'dataset_id': Dataset.objects.get(short_name=globals.ISMN).id,
+             'filter_widget_id': 'id_datasets-0-filters',
+             'param_filter_widget_id': 'id_datasets-0-paramfilters',
+             'initial_filters': '1,2',
+             'initial_paramfilters': '18,24',
+             'initial_paramfilter_params': ismn_networks + ";" + ismn_depths,
+             'initial_version': '5',
+             'initial_variable': '4'})
         self.assertEqual(response.status_code, 200)
         return_data = json.loads(response.content)
         assert return_data['versions']
         assert return_data['variables']
         assert return_data['filters']
+        assert return_data['paramfilters']
+
+        checked_filter_ids = [
+            "id_datasets-0-filters_0", "id_datasets-0-filters_1"
+        ]
+        for id in checked_filter_ids:
+            assert f'id="{id}" checked' in return_data["filters"]
+        assert return_data["versions"].startswith('<option value="5">')
+        assert return_data["variables"].startswith('<option value="4">')
+
+        # check parametrised filters
+        root = document_fromstring(return_data["paramfilters"])
+        for i, (id, val) in enumerate(
+                zip(["18", "24"], [ismn_networks, ismn_depths])):
+            assert val == root[0][i][5].value
+            assert id == root[0][i][2].value
 
         response = self.client.get(url, {'dataset_id': ''})
         self.assertEqual(response.status_code, 400)
@@ -657,7 +729,7 @@ class TestViews(TransactionTestCase):
         }
 
         result = self.client.post(url, validation_params)
-        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.status_code, 302)
 
     ## Stress test the server!
     @pytest.mark.long_running
@@ -755,6 +827,44 @@ class TestViews(TransactionTestCase):
             # check netcdf file
             netcdf_stream = io.BytesIO(b"".join(netcdf_result.streaming_content))
             assert netcdf_stream, 'netcdf file corrupt'
+
+    def test_redo_validation(self):
+        url = reverse("validation")
+        self.client.login(**self.credentials)
+        response = self.client.get(url, {"valrun_uuid": self.testrun.id})
+        self.assertEqual(response.status_code, 200)
+
+        val_form = response.context["val_form"]
+        ref_dc_form = response.context["ref_dc_form"]
+        dc_formset = response.context["dc_formset"]
+
+        # assert datasets are same as in setUp function
+        assert len(dc_formset) == 2
+        dc_form = dc_formset[0]
+        assert dc_form.initial["dataset"].short_name == "C3S"
+        assert len(dc_form.initial["filters"]) == 1
+        assert dc_form.initial["filters"][0].name == "FIL_ALL_VALID_RANGE"
+        assert dc_form.initial["version"].short_name == "C3S_V201812"
+        assert dc_form.initial["variable"].short_name == "C3S_sm"
+        dc_form = dc_formset[1]
+        assert dc_form.initial["dataset"].short_name == "SMOS"
+        assert len(dc_form.initial["filters"]) == 2
+        assert dc_form.initial["filters"][0].name == "FIL_ALL_VALID_RANGE"
+        assert dc_form.initial["filters"][1].name == "FIL_SMOS_UNFROZEN"
+        assert dc_form.initial["version"].short_name == "SMOS_105_ASC"
+        assert dc_form.initial["variable"].short_name == "SMOS_sm"
+        assert ref_dc_form.initial["dataset"].short_name == "ISMN"
+        assert (
+            ref_dc_form.initial["version"].short_name == "ISMN_V20180712_MINI"
+        )
+        assert (
+            ref_dc_form.initial["variable"].short_name == "ISMN_soil_moisture"
+        )
+
+        # assert some settings
+        assert val_form.initial["min_lat"] == -30
+        assert val_form.initial["max_lat"] == 30
+
 
     def test_access_to_results(self):
         self.client.login(**self.credentials2)

--- a/validator/views/validation.py
+++ b/validator/views/validation.py
@@ -18,7 +18,7 @@ from django.template import loader
 
 from validator.forms import DatasetConfigurationForm, FilterCheckboxSelectMultiple,\
     ValidationRunForm, ParamFilterChoiceField, ParamFilterSelectMultiple
-from validator.models import DataFilter, DatasetVersion
+from validator.models import DataFilter, DatasetVersion, DataVariable
 from validator.models import Dataset
 from validator.models import Settings
 from validator.models import ValidationRun, DatasetConfiguration
@@ -27,6 +27,7 @@ from validator.validation import run_validation
 import validator.validation.globals as val_globals
 from validator.validation.validation import stop_running_validation
 from django.db.models import Case, When
+from django.urls import reverse
 
 # see https://docs.djangoproject.com/en/2.1/topics/forms/formsets/
 DatasetConfigurationFormSet = formset_factory(DatasetConfigurationForm, extra=0, max_num=5, min_num=1, validate_max=True, validate_min=True)
@@ -207,12 +208,123 @@ def stop_validation(request, result_uuid):
 @login_required(login_url='/login/')
 def validation(request):
     dc_prefix = 'datasets'
-    ref_repfix = 'ref'
-    data_initial_values = [{'filters': DataFilter.objects.filter(name='FIL_ALL_VALID_RANGE'),
-                            'dataset': Dataset.objects.get(short_name=val_globals.C3S), }]
+    ref_prefix = 'ref'
 
-    ref_initial_values = {'filters': DataFilter.objects.filter(name='FIL_ALL_VALID_RANGE'),
-                          'dataset': Dataset.objects.get(short_name=val_globals.ISMN), }
+    # some parameters to pass to template
+    valrun_found = request.GET.get('valrun_found', None)
+    valrun_uuid = request.GET.get("valrun_uuid", None)
+    is_published = request.GET.get('is_published', None)
+    belongs_to_user = request.GET.get('belongs', None)
+    val_date = None
+
+    # Get initial values for dataset forms
+    def _default_initials():
+        ref_initial_values = {
+            "filters": DataFilter.objects.filter(
+                name="FIL_ALL_VALID_RANGE"
+            ),
+            "dataset": Dataset.objects.get(short_name=val_globals.ISMN),
+        }
+        data_initial_values = [{
+            "filters": DataFilter.objects.filter(
+                name="FIL_ALL_VALID_RANGE"
+            ),
+            "dataset": Dataset.objects.get(short_name=val_globals.C3S),
+        }]
+        return ref_initial_values, data_initial_values
+
+    # infer initial configuration values from POST request
+    if request.method == "POST":
+        def object_list_from_key(typ, key):
+            return list(map(
+                lambda x: typ.objects.get(pk=int(x)),
+                request.POST.getlist(key)
+            ))
+
+        def object_from_key(typ, key):
+            return typ.objects.get(pk=int(request.POST.get(key)[0]))
+
+        try:
+            prefixes = ["ref"]
+            num_forms = int(request.POST.get("datasets-TOTAL_FORMS")[0])
+            for i in range(num_forms):
+                prefixes.append(f"datasets-{i}")
+
+            initial_values = []
+            for pfx in prefixes:
+                initial_values.append({
+                    "filters": object_list_from_key(
+                        DataFilter, pfx + "-filters"
+                    ),
+                    "parametrised_filters": object_list_from_key(
+                        DataFilter, pfx + "-parametrised_filters"
+                    ),
+                    "paramfilter_params": request.POST.getlist(
+                        pfx + "-parametrised_filters_params"
+                    ),
+                    "dataset": object_from_key(
+                        Dataset, pfx + "-dataset"
+                    ),
+                    "version": object_from_key(
+                        DatasetVersion, pfx + "-version"
+                    ),
+                    "variable": object_from_key(
+                        DataVariable, pfx + "-variable"
+                    ),
+                })
+            ref_initial_values = initial_values[0]
+            data_initial_values = initial_values[1:]
+
+        except TypeError:
+            # happens with invalid requests
+            ref_initial_values, data_initial_values = _default_initials()
+
+    # infer initial configuration values from GET request
+    else:
+        valrun_uuid = request.GET.get("valrun_uuid", None)
+        if valrun_uuid is None:
+            ref_initial_values, data_initial_values = _default_initials()
+        else:
+            valrun = get_object_or_404(ValidationRun, pk=valrun_uuid)
+            # initial settings for datasets
+            ref_config = valrun.reference_configuration
+            data_configs = [dc for dc in valrun.dataset_configurations.all()
+                            if dc.id != ref_config.id]
+            initial_values = []
+            for dc in [ref_config] + data_configs:
+                initial_values.append({
+                    "filters": dc.filters.all(),
+                    "parametrised_filters": dc.parametrised_filters.all(),
+                    "dataset": dc.dataset,
+                    "version": dc.version,
+                    "variable": dc.variable,
+                })
+                if initial_values[-1]["parametrised_filters"]:
+                    initial_values[-1].update({
+                        "paramfilter_params": [
+                            fs.parameters
+                            for fs in dc.parametrisedfilter_set.all()
+                        ]
+                    })
+
+            ref_initial_values = initial_values[0]
+            data_initial_values = initial_values[1:]
+
+    # get initial values for the validation run settings
+    valrun_initial_values = {}
+    for field in ValidationRunForm.Meta.fields:
+        if request.method != "POST" and valrun_uuid is None:
+            valrun_initial_values = None
+        else:
+            if request.method == "POST":
+                valrun_initial_values[field] = request.POST.get(field)
+            else:
+                valrun_initial_values[field] = getattr(valrun, field)
+            # the dates should be without time
+            if isinstance(valrun_initial_values[field], datetime):
+                valrun_initial_values[field] = (
+                    valrun_initial_values[field].strftime("%Y-%m-%d")
+                )
 
     if request.method == "POST":
         if Settings.load().maintenance_mode:
@@ -232,9 +344,9 @@ def validation(request):
                 return HttpResponseBadRequest('Not a valid request: ' + e.message)
 
         # form for the reference configuration
-        ref_dc_form = DatasetConfigurationForm(request.POST, prefix=ref_repfix, is_reference=True, initial=ref_initial_values)
+        ref_dc_form = DatasetConfigurationForm(request.POST, prefix=ref_prefix, is_reference=True, initial=ref_initial_values)
         # form for the rest of the validation parameters
-        val_form = ValidationRunForm(request.POST)
+        val_form = ValidationRunForm(request.POST, initial=valrun_initial_values)
         if val_form.is_valid() and dc_formset.is_valid() and ref_dc_form.is_valid():
             newrun = val_form.save(commit=False)
             newrun.user = request.user
@@ -300,13 +412,13 @@ def validation(request):
                 newrun.delete()
                 comparison, is_published = (comparison_pub, comparison_pub['is_published'])
                 val_id = comparison['val_id']
-                val_date = ValidationRun.objects.get(id=val_id).start_time
                 belongs_to_user = comparison['belongs_to_user']
-                return render(request, 'validator/validate.html',
-                              {'val_form': val_form, 'dc_formset': dc_formset, 'ref_dc_form': ref_dc_form,
-                               'maintenance_mode': Settings.load().maintenance_mode, 'if_run_exists': if_run_exists,
-                               'val_id': val_id, 'is_published': is_published, 'belongs_to_user': belongs_to_user,
-                               'val_date': val_date})
+                validation_settings = reverse('validation') + \
+                                      '?valrun_uuid=' + str(val_id) + \
+                                      '&valrun_found=' + str(int(if_run_exists)) + \
+                                      '&is_published=' + str(int(is_published)) + \
+                                      '&belongs=' + str(int(belongs_to_user))
+                return redirect(validation_settings)
 
             # checking how many times the validation button was clicked - in try so that tests pass
             # need to close all db connections before forking, see
@@ -320,56 +432,108 @@ def validation(request):
         else:
             __logger.error("Errors in validation form {}\n{}\n{}".format(val_form.errors, dc_formset.errors, ref_dc_form.errors))
     else:
-        val_form = ValidationRunForm()
+        val_form = ValidationRunForm(initial=valrun_initial_values)
         dc_formset = DatasetConfigurationFormSet(prefix=dc_prefix, initial=data_initial_values)
-        ref_dc_form = DatasetConfigurationForm(prefix=ref_repfix, is_reference=True, initial=ref_initial_values)
+        ref_dc_form = DatasetConfigurationForm(prefix=ref_prefix, is_reference=True, initial=ref_initial_values)
         # ref_dc_form.
+
+        # if validation exists:
+        if valrun_found is not None:
+            val_date = ValidationRun.objects.get(id=valrun_uuid).start_time
+            valrun_found = bool(int(valrun_found))
+            is_published = bool(int(is_published))
+            belongs_to_user = bool(int(belongs_to_user))
 
     return render(request, 'validator/validate.html',
                   {'val_form': val_form, 'dc_formset': dc_formset, 'ref_dc_form': ref_dc_form,
-                   'maintenance_mode':Settings.load().maintenance_mode, 'if_run_exists':False, 'val_id': None})
+                   'maintenance_mode':Settings.load().maintenance_mode, 'if_run_exists': valrun_found,
+                   'val_id': valrun_uuid, 'is_published': is_published, 'belongs_to_user': belongs_to_user,
+                   'val_date': val_date})
 
 
 ## Ajax stuff required for validation view
 
 ## render string options as html
-def __render_options(entity_list):
+def __render_options(entity_list, initial):
     widgets = []
     for entity in entity_list:
         widget = {
-            'value' : entity.id,
+            'value': entity.id,
             'label': entity.pretty_name,
             }
         widgets.append(widget)
+    # reorder such that "initial" is at the front
+    if initial != "":
+        init_val = int(initial)
+        try:
+            init_idx = [w["value"] for w in widgets].index(init_val)
+            widgets.insert(0, widgets.pop(init_idx))
+        except ValueError:  # pragma: no cover
+            pass
 
     content = loader.render_to_string('widgets/select_options.html', {'widgets': widgets})
     return content
 
-# render filters as html checkboxes with descriptions
-def __render_filters(filters, filter_widget_id, parametrised = False):
-    widget_name = regex_subs(r'^id_', '', filter_widget_id)
-    if parametrised:
-        filter_field = ParamFilterChoiceField(widget=ParamFilterSelectMultiple, queryset=filters, required=False)
-    else:
-        filter_field = ModelMultipleChoiceField(widget=FilterCheckboxSelectMultiple, queryset=filters, required=False)
 
-    preselected = None
-    if filters:
-        # pre-select the first filter
-        preselected = filters[0].id
+# render filters as html checkboxes with descriptions
+def __render_filters(filters, filter_widget_id, initial_filters):
+    widget_name = regex_subs(r'^id_', '', filter_widget_id)
+    filter_field = ModelMultipleChoiceField(
+        widget=FilterCheckboxSelectMultiple, queryset=filters, required=False
+    )
+
+    # extracts the initial filters to be selected from the initial_filters
+    # string, see DatasetConfigurationForm.__init__
+    if filters and initial_filters:
+        initial_filter_ids = list(map(int, initial_filters.split(',')))
+    else:
+        initial_filter_ids = None
 
     filter_html = filter_field.widget.render(
         name=widget_name,
-        value=preselected,
+        value=initial_filter_ids,
         attrs={'id': filter_widget_id})
     return filter_html
 
-## returns the options for the variable and version select dropdowns and the filter checkboxes based on the selected dataset
+
+# render filters as html checkboxes with descriptions
+def __render_parametrised_filters(
+        filters, filter_widget_id, initial_filters, initial_params
+):
+    widget_name = regex_subs(r'^id_', '', filter_widget_id)
+    filter_field = ParamFilterChoiceField(
+        widget=ParamFilterSelectMultiple, queryset=filters, required=False
+    )
+
+    # extracts the initial filters and params to be selected from the
+    # initial_filters string, see DatasetConfigurationForm.__init__
+    if filters and initial_filters:
+        initial_filter_ids = list(map(int, initial_filters.split(",")))
+        initial_parameters = initial_params.split(";")
+    else:
+        initial_filter_ids = None
+        initial_parameters = None
+
+    filter_html = filter_field.widget.render(
+        name=widget_name,
+        value=initial_filter_ids,
+        attrs={'id': filter_widget_id,
+               'initial_params': initial_parameters})
+    return filter_html
+
+
+## returns the options for the variable and version select dropdowns and the
+## filter checkboxes based on the selected dataset
 @login_required(login_url='/login/')
 def ajax_get_dataset_options(request):
     selected_dataset_name = request.GET.get('dataset_id')
     filter_widget_id = request.GET.get('filter_widget_id')
     param_filter_widget_id = request.GET.get('param_filter_widget_id')
+    initial_filters = request.GET.get('initial_filters')
+    initial_paramfilters = request.GET.get('initial_paramfilters')
+    initial_paramfilter_params = request.GET.get('initial_paramfilter_params')
+    initial_version = request.GET.get('initial_version')
+    initial_variable = request.GET.get('initial_variable')
 
     try:
         selected_dataset = Dataset.objects.get(pk=selected_dataset_name)
@@ -377,10 +541,25 @@ def ajax_get_dataset_options(request):
         return HttpResponseBadRequest("Not a valid dataset")
 
     response_data = {
-        'versions': __render_options(selected_dataset.versions.all().order_by('-pretty_name')),
-        'variables': __render_options(selected_dataset.variables.all().order_by('id')),
-        'filters': __render_filters(selected_dataset.filters.filter(parameterised=False), filter_widget_id, parametrised = False),
-        'paramfilters': __render_filters(selected_dataset.filters.filter(parameterised=True), param_filter_widget_id, parametrised = True),
+        'versions': __render_options(
+            selected_dataset.versions.all().order_by('-pretty_name'),
+            initial_version,
+        ),
+        'variables': __render_options(
+            selected_dataset.variables.all().order_by('id'),
+            initial_variable
+        ),
+        'filters': __render_filters(
+            selected_dataset.filters.filter(parameterised=False),
+            filter_widget_id,
+            initial_filters,
+        ),
+        'paramfilters': __render_parametrised_filters(
+            selected_dataset.filters.filter(parameterised=True),
+            param_filter_widget_id,
+            initial_paramfilters,
+            initial_paramfilter_params,
+        ),
         }
 
     return JsonResponse(response_data)
@@ -427,4 +606,3 @@ def ajax_get_version_info(request):
         'intervals_to' : intervals_to
         }
     return JsonResponse(response_data)
-


### PR DESCRIPTION
* read filters and datasets from validation run

* added button to rerun validation

* selecting correct filters

* also remember version and variable; tests

* better visuals

- better button name
- better button order
- dates without time
- button on result page

* test for empty initial_filters

* test if initial filters is empty

* infer initial values also from POST

* fixes

* only change interval if it was not already set

* fixed validation time

* started work on parametrised filters

* redirecting with some parameters when there exists a validation

* test for existing validation updated according to changes in passing information

* running setTcLock so that it is possible to switch on and switch off tcol if more than 2 datasets are rendered by default

* pass parametrised filters and params to ajax_get_dataset_options

* networks render correctly

* remember whether tcol was activated

Co-authored-by: Samuel Scherrer <samuel.scherrer@posteo.de>
Co-authored-by: Samuel Scherrer <samuel.scherrer@geo.tuwien.ac.at>
Co-authored-by: sheenaze <tercjak@awst>