### PR TITLE
small styling changes added

### DIFF
--- a/validator/static/css/scheme.css
+++ b/validator/static/css/scheme.css
@@ -81,6 +81,10 @@
   width: 95%;
 }
 
+#id_ref-filters div > label.custom-control-label{
+  width: 95%;
+}
+
 .alert-danger {
     color: rgb(255, 108, 92);
     background-color: rgba(255, 108, 92, .15);


### PR DESCRIPTION
so that instead of: ![Screenshot from 2021-03-15 09-36-24](https://user-images.githubusercontent.com/57092960/111127745-76288680-8574-11eb-8b99-6ac10746fdd7.png)
we have:
![Screenshot from 2021-03-15 09-36-46](https://user-images.githubusercontent.com/57092960/111127783-7f195800-8574-11eb-85df-3675d2e37656.png)

