### PR TITLE
changed reader version in env

### DIFF
--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -166,7 +166,7 @@ dependencies:
     - pytest-cov==2.10.1
     - pytest-django==4.1.0
     - pytest-mpl==0.12
-    - qa4sm-reader==0.4.2
+    - qa4sm-reader==0.4.3
     - redis==3.5.3
     - repurpose==0.8
     - seaborn==0.11.0

--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -166,7 +166,7 @@ dependencies:
     - pytest-cov==2.10.1
     - pytest-django==4.1.0
     - pytest-mpl==0.12
-    - qa4sm-reader==0.4.3
+    - qa4sm-reader==0.4.4
     - redis==3.5.3
     - repurpose==0.8
     - seaborn==0.11.0

--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -166,7 +166,7 @@ dependencies:
     - pytest-cov==2.10.1
     - pytest-django==4.1.0
     - pytest-mpl==0.12
-    - qa4sm-reader==0.4.4
+    - qa4sm-reader==0.4.3
     - redis==3.5.3
     - repurpose==0.8
     - seaborn==0.11.0

--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -166,7 +166,7 @@ dependencies:
     - pytest-cov==2.10.1
     - pytest-django==4.1.0
     - pytest-mpl==0.12
-    - qa4sm-reader==0.4.3
+    - qa4sm-reader==0.4.4.1
     - redis==3.5.3
     - repurpose==0.8
     - seaborn==0.11.0


### PR DESCRIPTION
New qa4sm_reader version is v0.4.4 - Confidence Intervals are included in the boxplots

- [x] Failing test `test_validation.py::TestValidation::test_validation_c3s_ref` with reader version 0.4.4