### PR TITLE
Automatic statistics table to .csv 

### DIFF
--- a/UI/src/app/modules/validation-result/components/summary-statistics/summary-statistics.component.html
+++ b/UI/src/app/modules/validation-result/components/summary-statistics/summary-statistics.component.html
@@ -13,24 +13,27 @@
             </label>
           </ng-template>
           <div *ngIf="(table$|async) as table" class="p-pb-3">
-            <div *ngIf="table.hasOwnProperty('error')" class="p-pb-3"> This validation has resulted in a file whose size
+            <ng-template [ngIf]="table=='error file size'" [ngIfElse]="showTable" class="p-pb-3">
+              This validation has resulted in a file whose size
               exceeds the maximum limit; for this reason, the statistics table cannot be generated on the fly.
-            </div>
-            <div class="p-pb-3">The mean, median and standard deviation are calculated on the validation results aggregated by metric
-              and dataset. The reference dataset used is {{ (refDataset$ | async)?.pretty_name }}
-              ({{ (refDatasetVersion$ | async)?.pretty_name }}, {{ (refDatasetVariable$ | async)?.pretty_name }}).
-            </div>
-          <span [innerHtml]="table | dompurify"></span>
-          <div class="d-flex justify-content-between align-items-center">
-            <button pButton
-                    type="button"
-                    icon="pi pi-download"
-                    label="Download .csv table"
-                    class="btn-action-large"
-                    title="Download the table to a .csv file"
-                    (click)="getSummaryStatisticsAsCsv()">
-            </button>
-          </div>
+            </ng-template>
+            <ng-template #showTable>
+              <div class="p-pb-3">The mean, median and standard deviation are calculated on the validation results aggregated by metric
+                and dataset. The reference dataset used is {{ (refDataset$ | async)?.pretty_name }}
+                ({{ (refDatasetVersion$ | async)?.pretty_name }}, {{ (refDatasetVariable$ | async)?.pretty_name }}).
+              </div>
+              <span [innerHtml]="table | dompurify"></span>
+              <div class="d-flex justify-content-between align-items-center">
+                <button pButton
+                        type="button"
+                        icon="pi pi-download"
+                        label="Download .csv table"
+                        class="btn-action-large"
+                        title="Download the table to a .csv file"
+                        (click)="getSummaryStatisticsAsCsv()">
+                </button>
+              </div>
+            </ng-template>
           </div>
         </p-panel>
       </div>

--- a/UI/src/app/modules/validation-result/components/summary-statistics/summary-statistics.component.html
+++ b/UI/src/app/modules/validation-result/components/summary-statistics/summary-statistics.component.html
@@ -12,11 +12,14 @@
               <span class="p-panel-header-icon pi pi-question-circle help-icon"></span>
             </label>
           </ng-template>
-          <div class="p-pb-3">The mean, median and standard deviation are calculated on the validation results aggregated by metric
-            and dataset. The reference dataset used is {{ (refDataset$ | async)?.pretty_name }}
-            ({{ (refDatasetVersion$ | async)?.pretty_name }}, {{ (refDatasetVariable$ | async)?.pretty_name }}).
-          </div>
           <div *ngIf="(table$|async) as table" class="p-pb-3">
+            <div *ngIf="table.hasOwnProperty('error')" class="p-pb-3"> This validation has resulted in a file whose size
+              exceeds the maximum limit; for this reason, the statistics table cannot be generated on the fly.
+            </div>
+            <div class="p-pb-3">The mean, median and standard deviation are calculated on the validation results aggregated by metric
+              and dataset. The reference dataset used is {{ (refDataset$ | async)?.pretty_name }}
+              ({{ (refDatasetVersion$ | async)?.pretty_name }}, {{ (refDatasetVariable$ | async)?.pretty_name }}).
+            </div>
           <span [innerHtml]="table | dompurify"></span>
           <div class="d-flex justify-content-between align-items-center">
             <button pButton

--- a/UI/src/app/modules/validation-result/components/summary-statistics/summary-statistics.component.html
+++ b/UI/src/app/modules/validation-result/components/summary-statistics/summary-statistics.component.html
@@ -15,7 +15,7 @@
           <div *ngIf="(table$|async) as table" class="p-pb-3">
             <ng-template [ngIf]="table=='error file size'" [ngIfElse]="showTable" class="p-pb-3">
               This validation has resulted in a file whose size
-              exceeds the maximum limit; for this reason, the statistics table cannot be generated on the fly.
+              exceeds the maximum limit. For this reason, the statistics table cannot be generated on the fly.
             </ng-template>
             <ng-template #showTable>
               <div class="p-pb-3">The mean, median and standard deviation are calculated on the validation results aggregated by metric

--- a/api/views/serving_file_view.py
+++ b/api/views/serving_file_view.py
@@ -52,12 +52,25 @@ def get_results(request):
 def get_csv_with_statistics(request):
     validation_id = request.query_params.get('validationId', None)
     validation = get_object_or_404(ValidationRun, id=validation_id)
-    inspection_table = get_inspection_table(validation).reset_index()
+    inspection_table = get_inspection_table(validation)
+
+    if isinstance(inspection_table, str):
+        return JsonResponse(
+            {'message': 'Given validation output file size is too large to be read'},
+            status=404
+        )
 
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename=Stats_summary.csv'
 
-    inspection_table.to_csv(path_or_buf=response, sep=',', float_format='%.2f', index=False, decimal=".")
+    inspection_table.reset_index().to_csv(
+        path_or_buf=response,
+        sep=',',
+        float_format='%.2f',
+        index=False,
+        decimal="."
+    )
+
     return response
 
 
@@ -157,7 +170,17 @@ def get_summary_statistics(request):
     validation = get_object_or_404(ValidationRun, id=validation_id)
     # resetting index added, otherwise there would be a row shift between the index column header and the header of the
     # rest of the columns when df rendered as html
-    inspection_table = get_inspection_table(validation).reset_index()
+    inspection_table = get_inspection_table(validation)
 
-    return HttpResponse(inspection_table.to_html(table_id=None, classes=['table', 'table-bordered', 'table-striped'],
-                                                 index=False))
+    if isinstance(inspection_table, str):
+        return JsonResponse(
+            {'message': 'Given validation output file size is too large to be read'},
+            status=404
+        )
+
+    return HttpResponse(
+        inspection_table.reset_index().to_html(
+            table_id=None,
+            classes=['table', 'table-bordered', 'table-striped'],
+            index=False
+        ))

--- a/api/views/serving_file_view.py
+++ b/api/views/serving_file_view.py
@@ -175,10 +175,7 @@ def get_summary_statistics(request):
     inspection_table = get_inspection_table(validation)
 
     if isinstance(inspection_table, str):
-        return JsonResponse(
-            {'message': 'Given validation output file size is too large to be read'},
-            status=404
-        )
+        return HttpResponse('error file size')
 
     return HttpResponse(
         inspection_table.reset_index().to_html(

--- a/api/views/serving_file_view.py
+++ b/api/views/serving_file_view.py
@@ -56,10 +56,7 @@ def get_csv_with_statistics(request):
     inspection_table = get_inspection_table(validation)
 
     if isinstance(inspection_table, str):
-        return JsonResponse(
-            {'message': 'Given validation output file size is too large to be read'},
-            status=404
-        )
+        return HttpResponse('error file size', 404)
 
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename=Stats_summary.csv'

--- a/api/views/serving_file_view.py
+++ b/api/views/serving_file_view.py
@@ -50,6 +50,7 @@ def get_results(request):
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def get_csv_with_statistics(request):
+    """Download .csv of the statistics"""
     validation_id = request.query_params.get('validationId', None)
     validation = get_object_or_404(ValidationRun, id=validation_id)
     inspection_table = get_inspection_table(validation)
@@ -166,6 +167,7 @@ def get_graphic_file(request):
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def get_summary_statistics(request):
+    """Show statistics table on results page"""
     validation_id = request.query_params.get('id', None)
     validation = get_object_or_404(ValidationRun, id=validation_id)
     # resetting index added, otherwise there would be a row shift between the index column header and the header of the

--- a/api/views/validation_run_view.py
+++ b/api/views/validation_run_view.py
@@ -10,7 +10,7 @@ from rest_framework.serializers import ModelSerializer
 from api.views.auxiliary_functions import get_fields_as_list
 from validator.forms import PublishingForm
 from validator.models import ValidationRun, CopiedValidations
-from validator.validation import get_inspection_table
+
 
 
 

--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -209,7 +209,7 @@ dependencies:
     - pytest-cov==2.12.1
     - pytest-django==4.4.0
     - pytest-mpl==0.13
-    - qa4sm-reader==0.6.1
+    - qa4sm-reader==0.6.3
     - redis==3.5.3
     - repurpose==0.8
     - requests==2.26.0

--- a/validator/validation/graphics.py
+++ b/validator/validation/graphics.py
@@ -189,7 +189,7 @@ def get_inspection_table(validation_run):
 
         # Check that .csv file was created
         if stats_file is not None:
-            stats = pd.read_csv(stats_file)
+            stats = pd.read_csv(stats_file, index_col="Metric", dtype=str)
         # Check that file size is less than 100 MB
         elif file_size > 100*2**20:
             warnings.warn(

--- a/validator/validation/graphics.py
+++ b/validator/validation/graphics.py
@@ -1,4 +1,8 @@
+import warnings
+
 import matplotlib.pyplot as plt
+import pandas as pd
+
 plt.switch_backend('agg') ## this allows headless graph production
 
 import logging
@@ -38,9 +42,9 @@ def generate_all_graphs(validation_run, outfolder):
     __logger.debug('Trying to create zipfile {}'.format(zipfilename))
 
 
-    fnb, fnm = plot_all(validation_run.output_file.path,
+    fnb, fnm, fcsv = plot_all(validation_run.output_file.path,
         out_dir=outfolder, out_type='png')
-    fnb_svg, fnm_svg = plot_all(validation_run.output_file.path,
+    fnb_svg, fnm_svg, fcsv = plot_all(validation_run.output_file.path,
         out_dir=outfolder, out_type='svg')
 
 
@@ -169,10 +173,36 @@ def get_inspection_table(validation_run):
         Quick inspection table of the results.
     """
     outfile = validation_run.output_file
+    run_dir = path.join(OUTPUT_FOLDER, str(validation_run.id))
     # the first condition checks whether the outfile field has been properly
     # set, the second then whether the file really exists
     if bool(outfile) and path.exists(outfile.path):
-        return get_img_stats(outfile.path).drop(columns="Group")
+        file_size = os.path.getsize(outfile.path)
+
+        stats_file = None
+        for root, dirs, files in os.walk(run_dir):
+            for f in files:
+                if not f.endswith('.csv'): continue
+                else:
+                    stats_file = os.path.join(run_dir, f)
+                    break
+
+        # Check that .csv file was created
+        if stats_file is not None:
+            stats = pd.read_csv(stats_file)
+        # Check that file size is less than 100 MB
+        elif file_size > 100*2**20:
+            warnings.warn(
+                f"File size of {file_size} bytes is too large to be read"
+            )
+            # Return string to distinguish with 'None' in first conditional statement
+            return "No output"
+        else:
+            stats = get_img_stats(outfile.path)
+
+        stats = stats.drop(columns="Group", errors="ignore")
+        return stats
+
     else:
         # This happens when the output file has not been generated yet, because
         # the validation is still running. In this case the table won't be


### PR DESCRIPTION
Adapts QA4SM to read the .csv file generated by the QA4SM reader release v0.6.3.

- If the .csv file is present in the results, this is opened (validations with reader > v0.6.3)
- If not, and file size < 100 MB, the table is created on the fly
- Else, error message is shown

**Important**: this PR is only compatible with qa4sm reader >= 0.6.3.