### PR TITLE
Updated pytesmo version in env

### DIFF
--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -220,7 +220,7 @@ dependencies:
     - pygeobase==0.4.0
     - pygeogrids==0.4.1
     - pynetcf==0.2.2
-    - pytesmo==0.12.0
+    - pytesmo==0.13.2
     - pytest-cov==3.0.0
     - pytest-django==4.4.0
     - pytest-mpl==0.13


### PR DESCRIPTION
Updates Pytesmo after this PR: https://github.com/TUW-GEO/pytesmo/pull/256

Which solves the `('snr', dataset)` error : https://github.com/TUW-GEO/pytesmo/issues/251