### PR TITLE
Smos L2 filtering NaNs

### DIFF
--- a/validator/tests/test_filtering.py
+++ b/validator/tests/test_filtering.py
@@ -182,10 +182,11 @@ class TestValidation(TestCase):
         # Check that the 'COMBINED_RFI' field has been created
         index_should = ['Soil_Moisture', 'Soil_Moisture_DQX', 'Chi_2_P', 'RFI_Prob',
                         'Science_Flags', 'Days', 'Seconds', 'N_RFI_X', 'N_RFI_Y',
-                        'M_AVA0', 'COMBINED_RFI']
+                        'M_AVA0', 'Processing_Flags', 'Confidence_Flags', 'COMBINED_RFI']
         data_mean_should = np.array([
-            1.671967e-01, 2.292882e-02, 7.741764e-01, 4.255347e-03, 5.465900e+08, 5.178719e+17, 3.711064e+04,
-            4.400104e-01, 2.342201e-01, 1.607201e+02, 4.197295e-03])
+            1.680913e-01, 2.305116e-02, 7.749533e-01, 4.265946e-03, 5.465194e+08, 5.198555e+17, 3.708777e+04,
+            4.430680e-01, 2.353716e-01, 1.608706e+02, 2.769109e+00, 3.172377e+00, 4.220235e-03
+        ])
 
         filtered_mean_should = pd.Series(data=data_mean_should, index=index_should)
 
@@ -195,7 +196,7 @@ class TestValidation(TestCase):
 
         assert (filtered.COMBINED_RFI > .1).sum() == 0
         assert (filtered.RFI_Prob > .1).sum() == 0
-        assert len(filtered.index) == 3834
+        assert len(filtered.index) == 3794
         pd.testing.assert_series_equal(filtered.mean(), filtered_mean_should)
 
     def test_get_used_variables(self) -> None:

--- a/validator/tests/test_filtering.py
+++ b/validator/tests/test_filtering.py
@@ -183,10 +183,10 @@ class TestValidation(TestCase):
         index_should = ['Soil_Moisture', 'Soil_Moisture_DQX', 'Chi_2_P', 'RFI_Prob',
                         'Science_Flags', 'Days', 'Seconds', 'N_RFI_X', 'N_RFI_Y',
                         'M_AVA0', 'Processing_Flags', 'Confidence_Flags', 'COMBINED_RFI']
-        data_mean_should = np.array([1.62395873e-01, 2.02465384e-02, 6.27055087e-01, 1.06308409e-02,
-                                     5.45721648e+08, 5.08696150e+17, 2.32577243e+04, 2.91588785e+00,
-                                     2.50934579e+00, 2.03616822e+02, 2.44859813e+00, 1.28000000e+02,
-                                     2.87936946e-02])
+        data_mean_should = np.array(
+            [1.680913e-01, 2.305116e-02, 7.765892e-01, 9.556199e-03, 5.094559e+08, -1.121934e+18, 3.706094e+04,
+             1.850273e+00, 1.826263e+00, 1.364571e+02, 2.768545e+00, 2.817491e+01, 2.692703e-02
+             ])
 
         filtered_mean_should = pd.Series(data=data_mean_should, index=index_should)
 
@@ -197,7 +197,7 @@ class TestValidation(TestCase):
         assert (filtered.COMBINED_RFI > .1).sum() == 0
         assert (filtered.RFI_Prob > .1).sum() == 0
 
-        assert len(filtered.index) == 214
+        assert len(filtered.index) == 4588
         pd.testing.assert_series_equal(filtered.mean(), filtered_mean_should)
 
     def test_get_used_variables(self) -> None:

--- a/validator/tests/test_filtering.py
+++ b/validator/tests/test_filtering.py
@@ -182,11 +182,10 @@ class TestValidation(TestCase):
         # Check that the 'COMBINED_RFI' field has been created
         index_should = ['Soil_Moisture', 'Soil_Moisture_DQX', 'Chi_2_P', 'RFI_Prob',
                         'Science_Flags', 'Days', 'Seconds', 'N_RFI_X', 'N_RFI_Y',
-                        'M_AVA0', 'Processing_Flags', 'Confidence_Flags', 'COMBINED_RFI']
-        data_mean_should = np.array(
-            [1.680913e-01, 2.305116e-02, 7.765892e-01, 9.556199e-03, 5.094559e+08, -1.121934e+18, 3.706094e+04,
-             1.850273e+00, 1.826263e+00, 1.364571e+02, 2.768545e+00, 2.817491e+01, 2.692703e-02
-             ])
+                        'M_AVA0', 'COMBINED_RFI']
+        data_mean_should = np.array([
+            1.671967e-01, 2.292882e-02, 7.741764e-01, 4.255347e-03, 5.465900e+08, 5.178719e+17, 3.711064e+04,
+            4.400104e-01, 2.342201e-01, 1.607201e+02, 4.197295e-03])
 
         filtered_mean_should = pd.Series(data=data_mean_should, index=index_should)
 
@@ -196,8 +195,7 @@ class TestValidation(TestCase):
 
         assert (filtered.COMBINED_RFI > .1).sum() == 0
         assert (filtered.RFI_Prob > .1).sum() == 0
-
-        assert len(filtered.index) == 4588
+        assert len(filtered.index) == 3834
         pd.testing.assert_series_equal(filtered.mean(), filtered_mean_should)
 
     def test_get_used_variables(self) -> None:

--- a/validator/validation/filters.py
+++ b/validator/validation/filters.py
@@ -247,6 +247,10 @@ def setup_filtering(reader, filters, param_filters, dataset, variable) -> tuple:
     filtered_reader = reader
 
     masking_filters = []
+    adapter_kwargs = dict()
+
+    if dataset.short_name in ["SMOSL2_v700"]:
+        adapter_kwargs.update({"ignore_nans": True})
 
     for pfil in param_filters:
         __logger.debug(
@@ -473,7 +477,7 @@ def setup_filtering(reader, filters, param_filters, dataset, variable) -> tuple:
 
     if len(masking_filters):
         filtered_reader = AdvancedMaskingAdapter(filtered_reader, masking_filters,
-                                                 read_name=read_name)
+                                                 read_name=read_name, **adapter_kwargs)
     else:
         filtered_reader = BasicAdapter(filtered_reader, read_name=read_name)
 

--- a/validator/validation/filters.py
+++ b/validator/validation/filters.py
@@ -249,9 +249,6 @@ def setup_filtering(reader, filters, param_filters, dataset, variable) -> tuple:
     masking_filters = []
     adapter_kwargs = dict()
 
-    if dataset.short_name in ["SMOSL2_v700"]:
-        adapter_kwargs.update({"ignore_nans": True})
-
     for pfil in param_filters:
         __logger.debug(
             f"Setting up parametrised filter {pfil.filter.name} for "


### PR DESCRIPTION
This PR comes as a workaround for the fact that 0.0 values in the SMOS L2 data set were reprocessed as NaNs (due to the fillvalue = 0.0). It can be rolled back after a reprocessing of SMOS L2 (after PM6)