### PR TITLE
save validation also if all points failed

### DIFF
--- a/validator/validation/validation.py
+++ b/validator/validation/validation.py
@@ -514,7 +514,7 @@ def run_validation(validation_id):
         # once all tasks are finished:
         # only store parameters and produce graphs if validation wasn't cancelled and
         # we have metrics for at least one gpi - otherwise no netcdf output file
-        if (not validation_aborted) and (validation_run.ok_points > 0):
+        if (not validation_aborted):
             set_outfile(validation_run, run_dir)
             validation_run.save()
             save_validation_config(validation_run)


### PR DESCRIPTION
Now that the error codes are returned, it can be useful to see the results even if the calculation failed for all points. To fully work, some changes in qa4sm-reader are still required (https://github.com/awst-austria/qa4sm-reader/pull/60).