### PR TITLE
removed SMOS L2 reader adapter

### DIFF
--- a/validator/tests/test_filtering.py
+++ b/validator/tests/test_filtering.py
@@ -180,14 +180,12 @@ class TestValidation(TestCase):
         filtered = self.filtered_reader.read()
 
         # Check that the 'COMBINED_RFI' field has been created
-        index_should = ['Soil_Moisture', 'Soil_Moisture_DQX', 'Chi_2_P', 'RFI_Prob',
-                        'Science_Flags', 'Days', 'Seconds', 'N_RFI_X', 'N_RFI_Y',
-                        'M_AVA0', 'Processing_Flags', 'Confidence_Flags', 'COMBINED_RFI']
+        index_should = ['Soil_Moisture', 'Chi_2_P', 'RFI_Prob', 'Science_Flags', 'Days',
+                        'Seconds', 'N_RFI_X', 'N_RFI_Y', 'M_AVA0', 'COMBINED_RFI']
         data_mean_should = np.array([
-            1.680913e-01, 2.305116e-02, 7.749533e-01, 4.265946e-03, 5.465194e+08, 5.198555e+17, 3.708777e+04,
-            4.430680e-01, 2.353716e-01, 1.608706e+02, 2.769109e+00, 3.172377e+00, 4.220235e-03
+            1.677704e-01, 7.746283e-01, 4.264706e-03, 5.465586e+08, 5.191550e+17,
+            3.709878e+04, 4.419643e-01, 2.350315e-01, 1.608335e+02, 4.211758e-03,
         ])
-
         filtered_mean_should = pd.Series(data=data_mean_should, index=index_should)
 
         # check 'COMBINED_RFI' formula COMBINED_RFI = (N_RFI_X + N_RFI_Y) / M_AVA0
@@ -196,7 +194,7 @@ class TestValidation(TestCase):
 
         assert (filtered.COMBINED_RFI > .1).sum() == 0
         assert (filtered.RFI_Prob > .1).sum() == 0
-        assert len(filtered.index) == 3794
+        assert len(filtered.index) == 3808
         pd.testing.assert_series_equal(filtered.mean(), filtered_mean_should)
 
     def test_get_used_variables(self) -> None:

--- a/validator/validation/readers.py
+++ b/validator/validation/readers.py
@@ -25,37 +25,6 @@ from validator.models import UserDatasetFile
 __logger = logging.getLogger(__name__)
 
 
-class SMOSL2_FillnaAdapter(BasicAdapter):
-    """
-    Adapts the reading of SMOS L2 since NaNs should be considered
-    0.0 (special case)
-    """
-
-    def __init__(
-            self,
-            cls,
-            **kwargs,
-    ):
-        """
-        Parameters
-        ----------
-        cls : object
-            Reader object, has to have a `read_ts` or `read` method or a
-            method name must be specified in the `read_name` kwarg.
-            The same method will be available for the adapted version of the
-            reader.
-        """
-
-        super().__init__(cls, **kwargs)
-
-    def _adapt(self, data):
-        data = super()._adapt(data)
-
-        # if DataFrame is empty, needs to be returned in expected format
-        data = data[~np.isnan(data.Soil_Moisture)].fillna(.0)
-        return data
-
-
 def create_reader(dataset, version) -> GriddedNcTs:
     """
     Create basic readers (without any adapters / filters) for a dataset version
@@ -123,7 +92,6 @@ def create_reader(dataset, version) -> GriddedNcTs:
 
     if dataset.short_name == globals.SMOS_L2:
         reader = GriddedNcOrthoMultiTs(folder_name, ioclass_kws={'read_bulk': True})
-        reader = SMOSL2_FillnaAdapter(reader)
 
     if dataset.short_name == globals.SMAP_L2:
         reader = GriddedNcOrthoMultiTs(folder_name, ioclass_kws={'read_bulk': True})


### PR DESCRIPTION
After removing NaNs from SMOS L2 data set (reprocessed), ad hoc reader adapter for SMOS L2 can be removed. 