### PR TITLE
removed 0.0 as valid lower thres. for ISMN

### DIFF
--- a/validator/fixtures/variables.json
+++ b/validator/fixtures/variables.json
@@ -39,7 +39,7 @@
             "short_name": "soil_moisture",
             "pretty_name": "ISMN_soil_moisture",
             "help_text": "",
-            "min_value": 0.0,
+            "min_value": 0.001,
             "max_value": 1.0
         }
     },


### PR DESCRIPTION
The valid range of in situ is currently 0.0 - 1.0. However, 0.0 volumetric sm is hardly occurring in practice, and more often indicates a sensor malfunctioning.

While this should be dealt with in the ISMN data based through flagging, for many sensors it is still an issue. 

The 0.001 - 1.0 range should limit the impact of sensor malfunctioning.