### PR TITLE
maxdist for datasets

### DIFF
--- a/environment/qa4sm_env.yml
+++ b/environment/qa4sm_env.yml
@@ -268,5 +268,5 @@ dependencies:
     - xarray==0.18.2
     - zarr==2.11.3
     - ismn==1.3.2
-    - git+https://github.com/awst-austria/qa4sm-reader@master
+    - git+https://github.com/awst-austria/qa4sm-reader@864722a4b158c41a0b384cf94c97118f3c12f869
     - git+https://github.com/awst-austria/qa4sm-preprocessing@master

--- a/validator/models/dataset.py
+++ b/validator/models/dataset.py
@@ -37,3 +37,22 @@ class Dataset(models.Model):
         # I know it should be imported globally, but it doesn't work then
         from validator.validation.globals import NOT_AS_REFERENCE
         return self.short_name in NOT_AS_REFERENCE
+
+    @property
+    def resolution_in_m(self):
+        # we need the resolution in m in the distance lookup
+        # as a default value we use 30km
+        default = 30e3
+        if not isinstance(self.resolution, dict):
+            return default
+        if not "value" in self.resolution or not "unit" in self.resolution:
+            return default
+        val = self.resolution["value"]
+        unit = self.resolution["unit"]
+        if unit == "km":
+            return val * 1e3
+        elif unit == "deg":
+            # assuming 1deg approx 100km
+            return val * 100 * 1e3
+        else:
+            return default

--- a/validator/tests/test_models.py
+++ b/validator/tests/test_models.py
@@ -327,6 +327,14 @@ class TestModels(TestCase):
         print(dataset_str)
         assert dataset_str
 
+    def test_dataset_resolution(self):
+        mydataset = Dataset()
+        assert mydataset.resolution_in_m == 30e3
+        mydataset.resolution = {"value": 0.25, "unit": "deg"}
+        assert mydataset.resolution_in_m == 25e3
+        mydataset.resolution = {"value": 0.25, "unit": "km"}
+        assert mydataset.resolution_in_m == 250
+
     def test_version_str(self):
         mydatasetversion = DatasetVersion()
         dataset_str = str(mydatasetversion)

--- a/validator/validation/validation.py
+++ b/validator/validation/validation.py
@@ -239,7 +239,7 @@ def create_pytesmo_validation(validation_run):
             ds_num += 1
 
         ds_list.append((dataset_name, {'class': reader, 'columns': [dataset_config.variable.short_name],
-                                       'kwargs': read_kwargs}))
+                                       'kwargs': read_kwargs, 'max_dist': dataset_config.dataset.resolution_in_m}))
         ds_read_names.append((dataset_name, read_name))
 
         if (validation_run.spatial_reference_configuration and


### PR DESCRIPTION
I added the max_dist keyword for the datasets that will then be used by the pytesmo data manager.

Currently I get the resolution from the `Dataset` model, @sheenaze, so you can in the GUI just adapt `dataset.resolution` for the user data.