### PR TITLE
Use time stamp adapter to compute exact time

### DIFF
--- a/validator/fixtures/filters.json
+++ b/validator/fixtures/filters.json
@@ -660,8 +660,8 @@
         "pk": 43,
         "fields": {
             "name": "FIL_ISMN_FRM_representative",
-            "description": "Include only representative sensors (0-10 cm)",
-            "help_text": "Only ISMN sensors marked as 'representative' or 'very representative' are used. Other sensors ('not representative' or 'undeducible') are excluded from the validation run. Sensors below 10 cm depth are always excluded!",
+            "description": "Include only representative sensors (FRMs)",
+            "help_text": "Only ISMN sensors classified as 'representative' or 'very representative' following the FRM4SM standard are used. Other sensors ('not representative' or 'undeducible') are excluded from the validation run. Sensors below 10 cm depth are always excluded when this option is selected!",
             "parameterised": false,
             "dialog_name": null,
             "default_parameter": null,

--- a/validator/mailer.py
+++ b/validator/mailer.py
@@ -56,7 +56,7 @@ def send_val_done_notification(val_run):
 
     subject = '[QA4SM] Validation finished'
     body = 'Dear {} {},\n\nyour validation of {} with  {} ({})  data ' \
-           'as spatial reference and  {} ({}) data  as temporal referencehas been ' \
+           'as spatial reference and  {} ({}) data  as temporal reference has been ' \
            'completed.\nThe results are available at: {}.\nYou have until {} to inspect your validation - ' \
            'then it will be automatically removed (unless archived).\n\nBest regards,\nQA4SM team'.format(
         val_run.user.first_name,

--- a/validator/validation/readers.py
+++ b/validator/validation/readers.py
@@ -38,6 +38,7 @@ class SBPCAReader(GriddedNcOrthoMultiTs):
                 if col in ts.columns:
                     ts[col] = ts[col].fillna(0)
             ts = ts.dropna(subset='Soil_Moisture')
+            ts = ts.dropna(subset='acquisition_time')
         return ts
 
 def create_reader(dataset, version) -> GriddedNcTs:
@@ -112,8 +113,7 @@ def create_reader(dataset, version) -> GriddedNcTs:
         reader = GriddedNcOrthoMultiTs(folder_name, ioclass_kws={'read_bulk': True})
 
     if dataset.short_name == globals.SMOS_SBPCA:
-        reader = SBPCAReader(folder_name, ioclass_kws={'read_bulk': True},
-                             timevarname='acquisition_time')
+        reader = SBPCAReader(folder_name, ioclass_kws={'read_bulk': True})
 
     if dataset.user and len(dataset.user_dataset.all()):
         file = UserDatasetFile.objects.get(dataset=dataset)
@@ -146,6 +146,15 @@ def adapt_timestamp(reader, dataset, version):
             'base_time_field': 'Days',
             'base_time_units': 'ns',
             'base_time_reference': '2000-01-01',
+        }
+
+    elif dataset.short_name == globals.SMOS_SBPCA:
+        tadapt_kwargs = {
+            'base_time_field': 'acquisition_time',
+            'base_time_reference': '2000-01-01T00:00:00',
+            'base_time_units': 's',
+            'time_offset_fields': None,
+            'time_units': None,
         }
 
     elif dataset.short_name == globals.SMOS_IC:

--- a/validator/validation/readers.py
+++ b/validator/validation/readers.py
@@ -37,8 +37,10 @@ class SBPCAReader(GriddedNcOrthoMultiTs):
                         'Science_Flags']:
                 if col in ts.columns:
                     ts[col] = ts[col].fillna(0)
-            ts = ts.dropna(subset='Soil_Moisture')
-            ts = ts.dropna(subset='acquisition_time')
+            if 'Soil_Moisture' in ts.columns:
+                ts = ts.dropna(subset='Soil_Moisture')
+            if 'acquisition_time' in ts.columns:
+                ts = ts.dropna(subset='acquisition_time')
         return ts
 
 def create_reader(dataset, version) -> GriddedNcTs:


### PR DESCRIPTION
Fixing differences in exact time stamp of the SBPCA data leading to failing temp. matching in some locations when choosing a 1H window (time differences were up to 40 minutes).