### PR TITLE
Add command to create ISMN station list for users to download

### DIFF
--- a/validator/management/commands/generateismnlist.py
+++ b/validator/management/commands/generateismnlist.py
@@ -23,14 +23,17 @@ class Command(BaseCommand):
                                  'we use the latest version (based on the ID '
                                  'in the fixtures).', )
 
-    def _get_path_latest_ismn_version(self):
+    def _get_path_ismn_version(self, version_short_name=None):
         for dataset in Dataset.objects.all():
             if dataset.short_name == "ISMN":
-                latest_version = [v for v in dataset.versions.all()][-1]
-                return dataset, latest_version
+                if version_short_name is None:
+                    version = [v for v in dataset.versions.all()][-1]
+                else:
+                    version = dataset.versions.get(short_name=version_short_name)
+                return dataset, version
 
     def handle(self, *args, **options):
-        dataset, version = self._get_path_latest_ismn_version()
+        dataset, version = self._get_path_ismn_version(options['short_name'])
 
         target_path = options['target_path']
 

--- a/validator/management/commands/generateismnlist.py
+++ b/validator/management/commands/generateismnlist.py
@@ -1,0 +1,71 @@
+from django.core.management.base import BaseCommand
+import os
+
+from validator.models import DatasetVersion, Dataset
+from ismn.interface import ISMN_Interface
+from validator.validation.readers import create_reader
+
+
+class Command(BaseCommand):
+    help = "Create the list of ISMN sensor locations that the user can " \
+           "download from the `My datasets` page. This will also collect " \
+           "ISMN metadata and create the `python_metedata` directory if it " \
+           "doesn't exist yet."
+
+    def add_arguments(self, parser):
+        parser.add_argument("target_path", type=str,
+                            help='Directory where the ISMN sensor location '
+                                 'list will be stored in (existing file will '
+                                 'be overwritten).', )
+        parser.add_argument('-s', '--short_name', type=str,
+                            help='Optional. Short Name of the ISMN version '
+                                 'to base the list on. If not specified, '
+                                 'we use the latest version (based on the ID '
+                                 'in the fixtures).', )
+
+    def _get_path_latest_ismn_version(self):
+        for dataset in Dataset.objects.all():
+            if dataset.short_name == "ISMN":
+                latest_version = [v for v in dataset.versions.all()][-1]
+                return dataset, latest_version
+
+    def handle(self, *args, **options):
+        dataset, version = self._get_path_latest_ismn_version()
+
+        target_path = options['target_path']
+
+        print(f"Create user ISMN station list: \n "
+              f"From data: {dataset.storage_path}/{version.short_name} \n "
+              f"Target directory: {target_path}")
+
+        ds: ISMN_Interface = create_reader(dataset, version)
+
+        columns = [
+            ('network', 'val'),
+            ('station', 'val'),
+            ('instrument', 'val'),
+            ('latitude', 'val'),
+            ('longitude', 'val'),
+            ('instrument', 'depth_from'),
+            ('instrument', 'depth_to'),
+            ('timerange_from', 'val'),
+            ('timerange_to', 'val'),
+        ]
+
+        new_names = ['Network name', 'Station name', 'Instrument',
+                     'Latitude [deg]', 'Longitude [deg]',
+                     'Depth from [cm]', 'Depth to [cm]',
+                     'Period from', 'Period to']
+
+        if 'frm_class' in ds.metadata.columns.get_level_values(0):
+            columns.append(('frm_class', 'val'))
+            new_names.append('FRM Class')
+
+        df = ds.metadata.loc[:, columns]
+        df.columns = df.columns.droplevel(1)
+        df.columns = new_names
+        df.index.name = 'index'
+
+        fname = os.path.join(target_path, "ismn_station_list.csv")
+
+        df.to_csv(fname, index=False)

--- a/validator/tests/test_commands.py
+++ b/validator/tests/test_commands.py
@@ -7,6 +7,7 @@ import logging
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 import pandas as pd
+import os
 
 from dateutil.tz.tz import tzlocal
 from django.conf import settings
@@ -269,6 +270,9 @@ class TestCommands(TestCase):
         with TemporaryDirectory() as out_path:
             call_command('generateismnlist', out_path)
             df = pd.read_csv(out_path + '/ismn_station_list.csv')
-            assert df.index.size > 0
-            assert df.columns.size > 0
+            assert not df.empty
+            os.remove(out_path + '/ismn_station_list.csv')
+            call_command('generateismnlist', out_path, '-s', 'ISMN_V20191211')
+            df = pd.read_csv(out_path + '/ismn_station_list.csv')
+            assert not df.empty
 

--- a/validator/tests/test_commands.py
+++ b/validator/tests/test_commands.py
@@ -4,7 +4,9 @@ Test our custom django commands
 
 from datetime import datetime, timedelta
 import logging
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
+import pandas as pd
 
 from dateutil.tz.tz import tzlocal
 from django.conf import settings
@@ -17,6 +19,7 @@ from validator.models import ValidationRun
 from validator.tests.testutils import set_dataset_paths
 
 from django.contrib.auth import get_user_model
+
 User = get_user_model()
 
 
@@ -182,8 +185,6 @@ class TestCommands(TestCase):
         ended_vals3 = ValidationRun.objects.filter(end_time__isnull=False).count()
         assert ended_vals + 4 == ended_vals3
 
-
-
     def test_setdatasetpaths(self):
         new_test_path = 'new_test_path/'
         new_test_path2 = 'another_test_path/'
@@ -263,3 +264,11 @@ class TestCommands(TestCase):
         with patch('builtins.input', side_effect=user_input): ## this mocks user input for the command
             # run the command to list the paths
             call_command('getdatasetpaths', *args, **opts)
+
+    def test_generateismnlist(self):
+        with TemporaryDirectory() as out_path:
+            call_command('generateismnlist', out_path)
+            df = pd.read_csv(out_path + '/ismn_station_list.csv')
+            assert df.index.size > 0
+            assert df.columns.size > 0
+


### PR DESCRIPTION
Call it like `python manage.py generateismnlist /target/directory`. 

By default it will use the latest ismn version in the data base and set up an interface (if python metadata does not yet exist it will be created -> slow and needs write access to the ISMN folder). Normally python_metadata already exists,  in this case it will take a few seconds to export the list (will be faster after the next [ismn package release ](https://github.com/TUW-GEO/ismn/blob/master/CHANGELOG.rst) and only require write access to the target folder and not the ISMN data folder.