### PR TITLE
Change reader for new SMOS L2 Format and add overpass filter

### DIFF
--- a/validator/fixtures/versions.json
+++ b/validator/fixtures/versions.json
@@ -528,7 +528,7 @@
             "pretty_name": "v700",
             "help_text": "SMOS L2-SM (ESA)",
             "time_range_start": "2010-07-01",
-            "time_range_end": "2022-06-04",
+                "time_range_end": "2024-02-20",
             "geographical_range": null,
             "filters": [
                 1,
@@ -539,7 +539,9 @@
                 39,
                 40,
                 41,
-                42
+                42,
+                45,
+                46
             ]
         }
     },

--- a/validator/tests/auxiliary_functions.py
+++ b/validator/tests/auxiliary_functions.py
@@ -102,15 +102,19 @@ def generate_default_validation_smos():
     return run
 
 
-def generate_default_validation_smos_l2():
+def generate_default_validation_smos_l2(sbpca=False):
     run = ValidationRun()
     run.start_time = datetime.now(tzlocal())
     run.save()
 
     data_c = DatasetConfiguration()
     data_c.validation = run
-    data_c.dataset = Dataset.objects.get(short_name='SMOS_L2')
-    data_c.version = DatasetVersion.objects.get(short_name='SMOSL2_v700')
+    if sbpca:
+        data_c.dataset = Dataset.objects.get(short_name='SMOS_SBPCA')
+        data_c.version = DatasetVersion.objects.get(short_name='SMOS_SBPCA_v724')
+    else:
+        data_c.dataset = Dataset.objects.get(short_name='SMOS_L2')
+        data_c.version = DatasetVersion.objects.get(short_name='SMOSL2_v700')
     data_c.variable = DataVariable.objects.get(pretty_name='SMOSL2_sm')
     data_c.is_spatial_reference = False
     data_c.is_temporal_reference = False

--- a/validator/tests/test_filtering.py
+++ b/validator/tests/test_filtering.py
@@ -132,7 +132,7 @@ class TestValidation(TestCase):
     def test_reading_ColumnCombineAdapter(self) -> None:
         # test that the pytesmo.validation_framework.adapters.ColumnCombineAdapter
         # works properly for SMOS L2
-        self.run = generate_default_validation_smos_l2()
+        self.run = generate_default_validation_smos_l2(sbpca=True)
         self.user_data = {
             'username': 'testuser',
             'password': 'secret',
@@ -181,11 +181,12 @@ class TestValidation(TestCase):
 
         # Check that the 'COMBINED_RFI' field has been created
         index_should = ['Soil_Moisture', 'Chi_2_P', 'RFI_Prob', 'Science_Flags', 'Days',
-                        'Seconds', 'N_RFI_X', 'N_RFI_Y', 'M_AVA0', 'COMBINED_RFI']
-        data_mean_should = np.array([
-            1.677704e-01, 7.746283e-01, 4.264706e-03, 5.465586e+08, 5.191550e+17,
-            3.709878e+04, 4.419643e-01, 2.350315e-01, 1.608335e+02, 4.211758e-03,
-        ])
+                        'Seconds', 'N_RFI_X', 'N_RFI_Y', 'M_AVA0', 'Overpass', 'COMBINED_RFI']
+        data_mean_should = np.array(
+            [1.91801946e-01, 4.79034721e-01, 7.56410237e-03, 5.48010184e+08,
+             5.65984246e+17, 5.92144872e+04, 8.97435897e-01, 5.12820513e-01,
+             1.41410256e+02, 1.53846154e+00, 9.87404715e-03]
+        )
         filtered_mean_should = pd.Series(data=data_mean_should, index=index_should)
 
         # check 'COMBINED_RFI' formula COMBINED_RFI = (N_RFI_X + N_RFI_Y) / M_AVA0
@@ -194,7 +195,7 @@ class TestValidation(TestCase):
 
         assert (filtered.COMBINED_RFI > .1).sum() == 0
         assert (filtered.RFI_Prob > .1).sum() == 0
-        assert len(filtered.index) == 3808
+        assert len(filtered.index) == 39
         pd.testing.assert_series_equal(filtered.mean(), filtered_mean_should)
 
     def test_get_used_variables(self) -> None:

--- a/validator/validation/readers.py
+++ b/validator/validation/readers.py
@@ -2,6 +2,7 @@ import logging
 from os import path
 import numpy as np
 
+
 from ascat.read_native.cdr import AscatGriddedNcTs
 from c3s_sm.interface import C3STs as c3s_read
 from ecmwf_models.interface import ERATs
@@ -11,7 +12,8 @@ from ismn.interface import ISMN_Interface
 from ismn.custom import CustomSensorMetadataCsv
 from smap_io.interface import SMAPTs
 from smos.smos_ic.interface import SMOSTs
-from pynetcf.time_series import GriddedNcTs
+from pynetcf.time_series import GriddedNcTs, GriddedNcIndexedRaggedTs
+from pygeogrids.netcdf import load_grid
 
 from qa4sm_preprocessing.cgls_hr_ssm_swi.reader import S1CglsTs
 from qa4sm_preprocessing.reading import GriddedNcOrthoMultiTs, GriddedNcContiguousRaggedTs
@@ -109,7 +111,8 @@ def create_reader(dataset, version) -> GriddedNcTs:
         reader = SMOSTs(folder_name, ioclass_kws={'read_bulk': True})
 
     if dataset.short_name == globals.SMOS_L2:
-        reader = GriddedNcOrthoMultiTs(folder_name, ioclass_kws={'read_bulk': True})
+        reader = GriddedNcIndexedRaggedTs(folder_name, ioclass_kws={'read_bulk': True},
+                                          grid=load_grid(path.join(folder_name, "grid.nc")))
 
     if dataset.short_name == globals.SMAP_L2:
         reader = GriddedNcOrthoMultiTs(folder_name, ioclass_kws={'read_bulk': True})
@@ -141,14 +144,14 @@ def adapt_timestamp(reader, dataset, version):
             'base_time_reference': '2000-01-01',
         }
 
-    elif dataset.short_name == globals.SMOS_L2:
-        tadapt_kwargs = {
-            'time_offset_fields': 'Seconds',
-            'time_units': 's',
-            'base_time_field': 'Days',
-            'base_time_units': 'ns',
-            'base_time_reference': '2000-01-01',
-        }
+    # elif dataset.short_name == globals.SMOS_L2:
+    #     tadapt_kwargs = {
+    #         'time_offset_fields': 'Seconds',
+    #         'time_units': 's',
+    #         'base_time_field': 'Days',
+    #         'base_time_units': 'ns',
+    #         'base_time_reference': '2000-01-01',
+    #     }
 
     elif dataset.short_name == globals.SMOS_SBPCA:
         tadapt_kwargs = {


### PR DESCRIPTION
Testdata updated for new SMOS L2 Format
Data transferred to server (but not replaced old data yet)

We have to coordinate when we deploy this, so we can change the path on the server