### PR TITLE
resetting validation model added, to fix the problem with reloading d…

### DIFF
--- a/UI/src/app/pages/validate/validate.component.ts
+++ b/UI/src/app/pages/validate/validate.component.ts
@@ -68,32 +68,7 @@ export class ValidateComponent implements OnInit, AfterViewInit {
   @ViewChild('spatialReference') spatialReferenceChild: ValidationReferenceComponent;
   @ViewChild('temporalReference') temporalReferenceChild: ValidationReferenceComponent;
 
-  validationModel: ValidationModel = new ValidationModel(
-    [],
-    new ReferenceModel(null, null, null),
-    new SpatialSubsetModel(
-      new BehaviorSubject<number>(null),
-      new BehaviorSubject<number>(null),
-      new BehaviorSubject<number>(null),
-      new BehaviorSubject<number>(null),
-      new BehaviorSubject<boolean>(false),
-      new BehaviorSubject<number>(null),
-      new BehaviorSubject<number>(null),
-      new BehaviorSubject<number>(null),
-      new BehaviorSubject<number>(null)),
-    new ValidationPeriodModel(new BehaviorSubject<Date>(null), new BehaviorSubject<Date>(null)),
-    [],
-    new AnomaliesModel(
-      new BehaviorSubject<string>(ANOMALIES_NONE),
-      ANOMALIES_NONE_DESC,
-      new BehaviorSubject<Date>(null),
-      new BehaviorSubject<Date>(null)),
-    new TemporalMatchingModel(
-      new BehaviorSubject<number>(null),
-      'hours',
-    ),
-    new ScalingModel('', ''),
-    new BehaviorSubject<string>(''));
+  validationModel: ValidationModel;
 
   validationStart: Date = new Date('1978-01-01');
   validationEnd: Date = new Date();
@@ -135,6 +110,7 @@ export class ValidateComponent implements OnInit, AfterViewInit {
               private modalWindowService: ModalWindowService,
               private settingsService: SettingsService,
               public authService: AuthService) {
+    console.log('constructor')
   }
 
   ngAfterViewInit(): void {
@@ -143,23 +119,55 @@ export class ValidateComponent implements OnInit, AfterViewInit {
 
 
   ngOnInit(): void {
+    this.resetValidationModel();
     this.settingsService.getAllSettings().subscribe(setting => {
       this.maintenanceMode = setting[0].maintenance_mode;
     });
     this.modalWindowService.watch().subscribe(state => {
       this.isExistingValidationWindowOpen = state === 'open';
     });
-
+    console.log('on init')
     this.route.queryParams.subscribe(params => {
       if (params.validation_id) {
+        console.log('there are params')
         this.validationConfigService.getValidationConfig(params.validation_id).subscribe(
           this.getValidationConfigObserver
         );
       } else {
+        console.log('there are no params')
         this.setDefaultDatasetSettings();
       }
     });
     this.validationConfigService.listOfSelectedConfigs.next(this.validationModel.datasetConfigurations);
+  }
+
+  resetValidationModel(): void {
+    this.validationModel = new ValidationModel(
+      [],
+      new ReferenceModel(null, null, null),
+      new SpatialSubsetModel(
+        new BehaviorSubject<number>(null),
+        new BehaviorSubject<number>(null),
+        new BehaviorSubject<number>(null),
+        new BehaviorSubject<number>(null),
+        new BehaviorSubject<boolean>(false),
+        new BehaviorSubject<number>(null),
+        new BehaviorSubject<number>(null),
+        new BehaviorSubject<number>(null),
+        new BehaviorSubject<number>(null)),
+      new ValidationPeriodModel(new BehaviorSubject<Date>(null), new BehaviorSubject<Date>(null)),
+      [],
+      new AnomaliesModel(
+        new BehaviorSubject<string>(ANOMALIES_NONE),
+        ANOMALIES_NONE_DESC,
+        new BehaviorSubject<Date>(null),
+        new BehaviorSubject<Date>(null)),
+      new TemporalMatchingModel(
+        new BehaviorSubject<number>(null),
+        'hours',
+      ),
+      new ScalingModel('', ''),
+      new BehaviorSubject<string>(''));
   }
 
   private onGetValidationConfigNext(valrun): void {
@@ -178,6 +186,7 @@ export class ValidateComponent implements OnInit, AfterViewInit {
   }
 
   private setDefaultDatasetSettings(): void {
+    this.resetValidationModel();
     of({}).pipe(delay(0)).subscribe(() => {
       this.setDefaultGeographicalRange();
     });
@@ -220,7 +229,7 @@ export class ValidateComponent implements OnInit, AfterViewInit {
         new BehaviorSubject(false)
       );
       this.validationModel.datasetConfigurations.push(newDatasetConfigModel);
-      this.versionService.getVersionById(datasetConfig.version_id).subscribe( {
+      this.versionService.getVersionById(datasetConfig.version_id).subscribe({
         next: versionDto => {
           newDatasetConfigModel.datasetModel.selectedVersion = versionDto;
 


### PR DESCRIPTION
There was a problem with reloading validation settings - if a user reloaded settings and then navigated to the validate page using the validate menu button, the default settings would be added to the reloaded settings, instead of replacing them.