### PR TITLE
Fix ‘413 Request Entity Too Large’ error for uploads over 1 GB

### DIFF
--- a/docker/base/install.sh
+++ b/docker/base/install.sh
@@ -9,4 +9,6 @@ mkdir -p "$APP_DIR"
 wget -P /tmp/ https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/miniconda && ln -s /opt/miniconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && rm /tmp/Miniconda3-latest-Linux-x86_64.sh
 rsync -r "$WEB_VAL_GIT_DIR/" "$APP_DIR/" --exclude="tests" --exclude="db.sqlite3"
+/opt/miniconda/condabin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+/opt/miniconda/condabin/conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
 /opt/miniconda/condabin/conda env create --prefix=/var/lib/qa4sm-web-val/virtenv -f "$WEB_VAL_GIT_DIR/environment/qa4sm_env.yml"

--- a/docker/webapp/apache.conf
+++ b/docker/webapp/apache.conf
@@ -1,4 +1,5 @@
 <VirtualHost *:80>
+LimitRequestBody 2684354560
 LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" fwd
     Alias /static /var/lib/qa4sm-web-val/valentina/static
     <Directory /var/lib/qa4sm-web-val/valentina/static>


### PR DESCRIPTION
Changes

- Allow >1 GB uploads: Set LimitRequestBody in Apache config.
- Auto‑accept Conda licenses: Update docker/base/install.sh to include the Conda flag for channel Terms of Service.