### PR TITLE
Add the process duration and start time to the netcdf attributes

### DIFF
--- a/UI/developers-guide.md
+++ b/UI/developers-guide.md
@@ -3,7 +3,7 @@ QA4SM Angular UI
 
 ## Development environment - build tools
 Necessary software packages to run and build the UI
-- Node.js -> at least v18
+- Node.js -> at least v22 (might need to `nvm install 22` first)
 - npm
 - angular-cli
 For the current angular version please check package.json, this will imply which node.js version is needed. 

--- a/validator/tests/test_validation.py
+++ b/validator/tests/test_validation.py
@@ -246,6 +246,7 @@ class TestValidation(TestCase):
                 settings.APP_VERSION)
             assert str(run.id) in ds.url
             assert settings.SITE_URL in ds.url
+            assert ds.process_duration_seconds >= 0
 
             # check the metrics contained in the file
             for metric in self.metrics + tcol_metrics + stability_metrics:  # we dont test lon, lat, time etc.

--- a/validator/validation/validation.py
+++ b/validator/validation/validation.py
@@ -111,10 +111,10 @@ def set_outfile(validation_run, run_dir):
 
 def save_validation_config(validation_run):
     try:
-        with netCDF4.Dataset(os.path.join(OUTPUT_FOLDER,
+        with (netCDF4.Dataset(os.path.join(OUTPUT_FOLDER,
                                           validation_run.output_file.name),
                              "a",
-                             format="NETCDF4") as ds:
+                             format="NETCDF4") as ds):
 
             ds.qa4sm_version = settings.APP_VERSION
             ds.qa4sm_reader_version = qa4sm_reader.__version__
@@ -122,6 +122,12 @@ def save_validation_config(validation_run):
                 settings.APP_VERSION)
             ds.url = settings.SITE_URL + get_angular_url(
                 'result', validation_run.id)
+
+            # # Add validation run start time and duration to file
+            ds.process_start_time = str(pd.to_datetime(validation_run.start_time))
+            dt = int((pd.to_datetime(ds.date_created).tz_localize('UTC') -
+                      pd.to_datetime(ds.process_start_time)).seconds)
+            ds.process_duration_seconds = dt
 
             try:
                 if hasattr(validation_run, 'spatial_reference_configuration'):
@@ -252,8 +258,10 @@ def save_validation_config(validation_run):
                     validation_run.min_lat, validation_run.min_lon,
                     validation_run.max_lat, validation_run.max_lon)
 
+
     except Exception:
         __logger.exception('Validation configuration could not be stored.')
+
 
 
 def create_pytesmo_validation(validation_run):


### PR DESCRIPTION
In order provide the run time in the automated validation reports, I need either an API call that returns the information, or I need to have it in the netcdf file. I think the API solution would be better, but for now I added it to the netcdf attributes. Note that the netcdf file is written before the plots are made, which means the run time in the netcdf file might be different from the time reported on the results page, which might be confusing -> ideally they should be the same therefore the API solution would still be preferred.